### PR TITLE
serialized meta_value including html tags

### DIFF
--- a/includes/admin/views/html-admin-page-entries-view.php
+++ b/includes/admin/views/html-admin-page-entries-view.php
@@ -43,7 +43,16 @@ $hide_empty = isset( $_COOKIE['everest_forms_entry_hide_empty'] ) && 'true' === 
 												continue;
 											}
 
-											$field_value = apply_filters( 'everest_forms_html_field_value', wp_strip_all_tags( $meta_value ), $entry_meta[ $meta_key ], $entry_meta, 'entry-single' );
+											if ( is_serialized( $meta_value ) )
+                                            {
+                                                // don't strip the tags here
+												$field_value = apply_filters( 'everest_forms_html_field_value',  $meta_value, $entry_meta[ $meta_key ], $entry_meta, 'entry-single' );
+                                            }
+                                            else
+                                            {
+                                                $field_value = apply_filters( 'everest_forms_html_field_value', wp_strip_all_tags( $meta_value ), $entry_meta[ $meta_key ], $entry_meta, 'entry-single' );
+                                            }
+											
 											$field_class = empty( $field_value ) ? ' empty' : '';
 											$field_style = $hide_empty && empty( $field_value ) ? 'display:none;' : '';
 
@@ -65,7 +74,7 @@ $hide_empty = isset( $_COOKIE['everest_forms_entry_hide_empty'] ) && 'true' === 
 														$field_value = maybe_unserialize( $field_value );
 
 														foreach ( $field_value as $field => $value ) {
-															echo '<span class="list">' . $value . '</span>';
+															echo '<span class="list">' . wp_strip_all_tags( $value ) . '</span>';
 														}
 													} else {
 														echo nl2br( make_clickable( $field_value ) );


### PR DESCRIPTION
entries with serialized meta_value's including html tags are invisible on the admin screen because stripping out the html tags from the serialized db entry will result in invalid serialization data and therefore maybe_unserialize will return false

e.g. a check box with url and text as choice:

a:1:{i:0;s:84:"Datenschutzbestimmungen gelesen und akzeptiert";}

strip the tags and you will get:

a:1:{i:0;s:84:"Datenschutzbestimmungen gelesen und akzeptiert";}

unserialize will fail here because of the invalid string length (s:84)