### PR TITLE
Migrating settings option name

### DIFF
--- a/includes/admin/settings/class-evf-settings-email.php
+++ b/includes/admin/settings/class-evf-settings-email.php
@@ -45,7 +45,7 @@ class EVF_Settings_Email extends EVF_Settings_Page {
 				array(
 					'title'   => __( 'Template', 'everest-forms' ),
 					'type'    => 'radio',
-					'id'      => 'evf_email_template',
+					'id'      => 'everest_forms_email_template',
 					'default' => 'default',
 					'options' => array(
 						'default' => esc_html__( 'HTML', 'everest-forms' ),

--- a/includes/admin/settings/class-evf-settings-recaptcha.php
+++ b/includes/admin/settings/class-evf-settings-recaptcha.php
@@ -46,7 +46,7 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Site Key', 'everest-forms' ),
 					'desc'     => __( 'Get site key from google.', 'everest-forms' ),
-					'id'       => 'evf_recaptcha_site_key',
+					'id'       => 'everest_forms_recaptcha_site_key',
 					'default'  => '',
 					'type'     => 'text',
 					'class'    => '',

--- a/includes/admin/settings/class-evf-settings-recaptcha.php
+++ b/includes/admin/settings/class-evf-settings-recaptcha.php
@@ -57,7 +57,7 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Secret Key', 'everest-forms' ),
 					'desc'     => __( 'Get secret key from google.', 'everest-forms' ),
-					'id'       => 'evf_recaptcha_site_secret',
+					'id'       => 'everest_forms_recaptcha_site_secret',
 					'default'  => '',
 					'type'     => 'text',
 					'class'    => '',

--- a/includes/admin/settings/class-evf-settings-validation.php
+++ b/includes/admin/settings/class-evf-settings-validation.php
@@ -46,7 +46,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Required', 'everest-forms' ),
 					'desc'     => __( 'Enter the message for the required form field', 'everest-forms' ),
-					'id'       => 'evf_required_validation',
+					'id'       => 'everest_forms_required_validation',
 					'type'     => 'text',
 					'desc_tip' => true,
 					'css'      => 'min-width: 350px;',
@@ -55,7 +55,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Website URL', 'everest-forms' ),
 					'desc'     => __( 'Enter the message for the valid website url', 'everest-forms' ),
-					'id'       => 'evf_url_validation',
+					'id'       => 'everest_forms_url_validation',
 					'type'     => 'text',
 					'desc_tip' => true,
 					'css'      => 'min-width: 350px;',
@@ -64,7 +64,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Email', 'everest-forms' ),
 					'desc'     => __( 'Enter the message for the valid email', 'everest-forms' ),
-					'id'       => 'evf_email_validation',
+					'id'       => 'everest_forms_email_validation',
 					'type'     => 'text',
 					'desc_tip' => true,
 					'css'      => 'min-width: 350px;',
@@ -73,7 +73,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'Number', 'everest-forms' ),
 					'desc'     => __( 'Enter the message for the valid number', 'everest-forms' ),
-					'id'       => 'evf_number_validation',
+					'id'       => 'everest_forms_number_validation',
 					'type'     => 'text',
 					'desc_tip' => true,
 					'css'      => 'min-width: 350px;',
@@ -82,7 +82,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 				array(
 					'title'    => __( 'reCAPTCHA', 'everest-forms' ),
 					'desc'     => __( 'Enter the message for the valid recaptcha', 'everest-forms' ),
-					'id'       => 'evf_recaptcha_validation',
+					'id'       => 'everest_forms_recaptcha_validation',
 					'type'     => 'text',
 					'desc_tip' => true,
 					'css'      => 'min-width: 350px;',

--- a/includes/admin/settings/class-evf-settings-validation.php
+++ b/includes/admin/settings/class-evf-settings-validation.php
@@ -22,7 +22,7 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 	 */
 	public function __construct() {
 		$this->id    = 'validation';
-		$this->icon  = 'evf-icon  evf-icon-checkbox';
+		$this->icon  = 'evf-icon evf-icon-checkbox';
 		$this->label = __( 'Validations', 'everest-forms' );
 
 		parent::__construct();
@@ -36,7 +36,6 @@ class EVF_Settings_Validation extends EVF_Settings_Page {
 	public function get_settings() {
 		$settings = apply_filters(
 			'everest_forms_validation_settings', array(
-
 				array(
 					'title' => __( 'Validation Messages', 'everest-forms' ),
 					'type'  => 'title',

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -26,8 +26,8 @@ if ( ! $tab_exists ) {
 			do_action( 'everest_forms_settings_tabs' );
 			?>
 		</nav>
-		<h1 class="screen-reader-text"><?php echo esc_html( $current_tab_label['label'] ); ?></h1>
 		<div class="everest-forms-settings">
+			<h1 class="screen-reader-text"><?php echo esc_html( $current_tab_label['label'] ); ?></h1>
 			<?php
 				do_action( 'everest_forms_sections_' . $current_tab );
 

--- a/includes/class-evf-emails.php
+++ b/includes/class-evf-emails.php
@@ -501,7 +501,7 @@ class EVF_Emails {
 	 */
 	public function get_template() {
 		if ( ! $this->template ) {
-			$this->template = get_option( 'evf_email_template', 'default' );
+			$this->template = get_option( 'everest_forms_email_template', 'default' );
 		}
 
 		return apply_filters( 'everest_forms_email_template', $this->template );

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -115,7 +115,7 @@ class EVF_Form_Task {
 					$data  = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $secret_key . '&response=' . $_POST['g-recaptcha-response'] );
 					$data  = json_decode( wp_remote_retrieve_body( $data ) );
 					if ( empty( $data->success ) ) {
-						evf_add_notice( get_option( 'evf_recaptcha_validation', __( 'Incorrect reCAPTCHA, please try again.', 'everest-forms' ) ), 'error' );
+						evf_add_notice( get_option( 'everest_forms_recaptcha_validation', __( 'Incorrect reCAPTCHA, please try again.', 'everest-forms' ) ), 'error' );
 						return;
 					}
 				} else {

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -103,13 +103,13 @@ class EVF_Form_Task {
 			}
 
 			// reCAPTCHA check.
-			$site_key   = get_option( 'everest_forms_recaptcha_site_key', '' );
-			$secret_key = get_option( 'everest_forms_recaptcha_site_secret', '' );
+			$site_key   = get_option( 'everest_forms_recaptcha_site_key' );
+			$secret_key = get_option( 'everest_forms_recaptcha_site_secret' );
 			if (
 				! empty( $site_key ) &&
 				! empty( $secret_key ) &&
 				isset( $form_data['settings']['recaptcha_support'] ) &&
-				'1' == $form_data['settings']['recaptcha_support']
+				'1' === $form_data['settings']['recaptcha_support']
 			) {
 				if ( ! empty( $_POST['g-recaptcha-response'] ) ) {
 					$data  = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $secret_key . '&response=' . $_POST['g-recaptcha-response'] );

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -103,8 +103,8 @@ class EVF_Form_Task {
 			}
 
 			// reCAPTCHA check.
-			$site_key   = get_option( 'evf_recaptcha_site_key', '' );
-			$secret_key = get_option( 'evf_recaptcha_site_secret', '' );
+			$site_key   = get_option( 'everest_forms_recaptcha_site_key', '' );
+			$secret_key = get_option( 'everest_forms_recaptcha_site_secret', '' );
 			if (
 				! empty( $site_key ) &&
 				! empty( $secret_key ) &&

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -270,11 +270,11 @@ class EVF_Frontend_Scripts {
 				$params = array(
 					'ajax_url'                => EVF()->ajax_url(),
 					'everest_forms_data_save' => wp_create_nonce( 'everest_forms_data_save_nonce' ),
- 					'i18n_messages_required'  => get_option( 'evf_required_validation' ),
- 					'i18n_messages_url'       => get_option( 'evf_url_validation' ),
- 					'i18n_messages_email'     => get_option( 'evf_email_validation' ),
- 					'i18n_messages_number'    => get_option( 'evf_number_validation' ),
-					'i18n_messages_recaptcha' => get_option( 'evf_recaptcha_validation' ),
+ 					'i18n_messages_required'  => get_option( 'everest_forms_required_validation' ),
+ 					'i18n_messages_url'       => get_option( 'everest_forms_url_validation' ),
+ 					'i18n_messages_email'     => get_option( 'everest_forms_email_validation' ),
+ 					'i18n_messages_number'    => get_option( 'everest_forms_number_validation' ),
+					'i18n_messages_recaptcha' => get_option( 'everest_forms_recaptcha_validation' ),
  				);
 			break;
 			default:

--- a/includes/class-evf-install.php
+++ b/includes/class-evf-install.php
@@ -519,7 +519,7 @@ CREATE TABLE {$wpdb->prefix}evf_sessions (
 				) );
 			}
 
-			update_option( 'evf_default_form_page_id', $form_id );
+			update_option( 'everest_forms_default_form_page_id', $form_id );
 		}
 	}
 

--- a/includes/class-evf-install.php
+++ b/includes/class-evf-install.php
@@ -39,6 +39,10 @@ class EVF_Install {
 			'evf_update_116_delete_options',
 			'evf_update_116_db_version',
 		),
+		'1.2.0' => array(
+			'evf_update_120_db_rename_options',
+			'evf_update_120_db_version',
+		),
 	);
 
 	/**

--- a/includes/evf-update-functions.php
+++ b/includes/evf-update-functions.php
@@ -94,3 +94,10 @@ function evf_update_116_delete_options() {
 function evf_update_116_db_version() {
 	EVF_Install::update_db_version( '1.1.6' );
 }
+
+/**
+ * Update DB Version.
+ */
+function evf_update_120_db_version() {
+	EVF_Install::update_db_version( '1.2.0' );
+}

--- a/includes/evf-update-functions.php
+++ b/includes/evf-update-functions.php
@@ -96,6 +96,25 @@ function evf_update_116_db_version() {
 }
 
 /**
+ * Update settings option to use new renamed option for 1.2.0.
+ */
+function evf_update_120_db_rename_options() {
+	$rename_options = array(
+		'evf_recaptcha_site_key'    => 'everest_forms_recaptcha_site_key',
+		'evf_recaptcha_site_secret' => 'everest_forms_recaptcha_site_secret',
+	);
+
+	foreach ( $rename_options as $old_option => $new_option ) {
+		$raw_old_option = get_option( $old_option );
+
+		if ( ! empty( $raw_old_option ) ) {
+			update_option( $new_option, $raw_old_option );
+			delete_option( $old_option );
+		}
+	}
+}
+
+/**
  * Update DB Version.
  */
 function evf_update_120_db_version() {

--- a/includes/evf-update-functions.php
+++ b/includes/evf-update-functions.php
@@ -100,8 +100,15 @@ function evf_update_116_db_version() {
  */
 function evf_update_120_db_rename_options() {
 	$rename_options = array(
+		'evf_email_template'        => 'everest_forms_email_template',
 		'evf_recaptcha_site_key'    => 'everest_forms_recaptcha_site_key',
 		'evf_recaptcha_site_secret' => 'everest_forms_recaptcha_site_secret',
+		'evf_required_validation'   => 'everest_forms_required_validation',
+		'evf_url_validation'        => 'everest_forms_url_validation',
+		'evf_email_validation'      => 'everest_forms_email_validation',
+		'evf_number_validation'     => 'everest_forms_number_validation',
+		'evf_recaptcha_validation'  => 'everest_forms_recaptcha_validation',
+		'evf_default_form_page_id'  => 'everest_forms_default_form_page_id',
 	);
 
 	foreach ( $rename_options as $old_option => $new_option ) {

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -254,9 +254,9 @@ class EVF_Shortcode_Form {
 	 * @param array $form_data
 	 */
 	public static function process_recaptcha( $form_data ){
-		$site_key   = get_option( 'everest_forms_recaptcha_site_key', '' );
-		$secret_key = get_option( 'everest_forms_recaptcha_site_secret', '' );
-		if ( ! $site_key || ! $secret_key ) {
+		$site_key   = get_option( 'everest_forms_recaptcha_site_key' );
+		$secret_key = get_option( 'everest_forms_recaptcha_site_secret' );
+		if ( ! empty( $site_key ) || ! empty( $secret_key ) ) {
 			return;
 		}
 

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -254,8 +254,8 @@ class EVF_Shortcode_Form {
 	 * @param array $form_data
 	 */
 	public static function process_recaptcha( $form_data ){
-		$site_key   = get_option( 'evf_recaptcha_site_key', '' );
-		$secret_key = get_option( 'evf_recaptcha_site_secret', '' );
+		$site_key   = get_option( 'everest_forms_recaptcha_site_key', '' );
+		$secret_key = get_option( 'everest_forms_recaptcha_site_secret', '' );
 		if ( ! $site_key || ! $secret_key ) {
 			return;
 		}

--- a/uninstall.php
+++ b/uninstall.php
@@ -29,7 +29,7 @@ if ( defined( 'EVF_REMOVE_ALL_DATA' ) && true === EVF_REMOVE_ALL_DATA ) {
 	EVF_Install::drop_tables();
 
 	// Pages.
-	wp_trash_post( get_option( 'evf_default_form_page_id' ) );
+	wp_trash_post( get_option( 'everest_forms_default_form_page_id' ) );
 
 	// Delete options.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'evf\_%';" );


### PR DESCRIPTION
This PR consists of migration script which need to be review throughly for renaming settings option name.

Below are the old option name => new option name.

```
'evf_email_template'        => 'everest_forms_email_template',
'evf_recaptcha_site_key'    => 'everest_forms_recaptcha_site_key',
'evf_recaptcha_site_secret' => 'everest_forms_recaptcha_site_secret',
'evf_required_validation'   => 'everest_forms_required_validation',
'evf_url_validation'        => 'everest_forms_url_validation',
'evf_email_validation'      => 'everest_forms_email_validation',
'evf_number_validation'     => 'everest_forms_number_validation',
'evf_recaptcha_validation'  => 'everest_forms_recaptcha_validation',
'evf_default_form_page_id'  => 'everest_forms_default_form_page_id',
```
