### PR TITLE
 Deprecated - everest_forms_sanitize_textarea_field to evf_sanitize_textarea_field

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -947,9 +947,11 @@
 		bindGridSwitcher: function () {
 			$('body').on('click', '.evf-show-grid', function (e) {
 				e.stopPropagation();
+				EVFPanelBuilder.checkEmptyGrid();
 				$(this).closest('.evf-toggle-row').find('.evf-toggle-row-content').stop(true).slideToggle(200);
 			});
 			$(document).click(function () {
+				EVFPanelBuilder.checkEmptyGrid();
 				$('.evf-show-grid').closest('.evf-toggle-row').find('.evf-toggle-row-content').stop(true).slideUp(200);
 			});
 			var max_number_of_grid = 2;

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -952,9 +952,6 @@
 			$(document).click(function () {
 				$('.evf-show-grid').closest('.evf-toggle-row').find('.evf-toggle-row-content').stop(true).slideUp(200);
 			});
-			$('.evf-toggle-row-content').click(function (e) {
-				e.stopPropagation();
-			});
 			var max_number_of_grid = 2;
 			$('body').on('click', '.evf-grid-selector', function () {
 				var $this_single_row = $(this).closest('.evf-admin-row');

--- a/includes/abstracts/abstract-evf-form-fields.php
+++ b/includes/abstracts/abstract-evf-form-fields.php
@@ -824,7 +824,7 @@ abstract class EVF_Form_Fields {
 		$name = ! empty( $form_data['form_fields'][ $field_id ]['label'] ) ? sanitize_text_field( $form_data['form_fields'][ $field_id ]['label'] ) : '';
 
 		// Sanitize but keep line breaks.
-		$value = everest_forms_sanitize_textarea_field( $field_submit );
+		$value = evf_sanitize_textarea_field( $field_submit );
 
 		EVF()->task->form_fields[ $field_id ] = array(
 			'name'     => $name,

--- a/includes/class-evf-emails.php
+++ b/includes/class-evf-emails.php
@@ -361,7 +361,7 @@ class EVF_Emails {
 
 		if ( $sanitize ) {
 			if ( $linebreaks ) {
-				$tag = everest_forms_sanitize_textarea_field( $tag );
+				$tag = evf_sanitize_textarea_field( $tag );
 			} else {
 				$tag = sanitize_text_field( $tag );
 			}

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -888,8 +888,7 @@ function evf_get_form_fields( $form = false, $whitelist = array() ) {
  *
  * @return string
  */
-function everest_forms_sanitize_textarea_field( $string ) {
-
+function evf_sanitize_textarea_field( $string ) {
 	if ( empty( $string ) || ! is_string( $string ) ) {
 		return $string;
 	}

--- a/includes/evf-deprecated-functions.php
+++ b/includes/evf-deprecated-functions.php
@@ -161,3 +161,12 @@ function get_form_data_by_meta_key( $form_id, $meta_key ) {
 function evf_query_string_form_fields( $values = null, $exclude = array(), $current_key = '', $return = false ) {
 	evf_deprecated_function( 'evf_sender_address', '1.2.0' );
 }
+
+/**
+ * @deprecated 1.2.0
+ */
+function everest_forms_sanitize_textarea_field( $string ) {
+	evf_deprecated_function( 'everest_forms_sanitize_textarea_field', '1.2.0', 'evf_sanitize_textarea_field' );
+	return evf_sanitize_textarea_field( $string );
+}
+

--- a/includes/fields/class-evf-field-textarea.php
+++ b/includes/fields/class-evf-field-textarea.php
@@ -134,7 +134,7 @@ class EVF_Field_Textarea extends EVF_Form_Fields {
 			$value = $primary['attr']['value'];
 			unset( $primary['attr']['value'] );
 
-			$value = everest_forms_sanitize_textarea_field( $value );
+			$value = evf_sanitize_textarea_field( $value );
 		}
 
 		// Primary field.


### PR DESCRIPTION
This PR is for deprecating the function  everest_forms_sanitize_textarea_field to evf_sanitize_textarea_field, and also the fixes the issue while switching the form colum.