### PR TITLE
Allow FlatPickr on mobile devices

### DIFF
--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -23,7 +23,9 @@ jQuery( function ( $ ) {
 			}
 		},
 		init_datepicker: function () {
-			$( '.flatpickr-field' ).flatpickr();
+			$( '.flatpickr-field' ).flatpickr({
+				disableMobile: true
+			});
 		},
 		load_validation: function() {
 			if ( typeof $.fn.validate === 'undefined' ) {


### PR DESCRIPTION
This PR allows FlatPickr on mobile devices too, disabling Inputs fall back to being HTML5 date inputs.