### PR TITLE
Fix tooltip issue on email new notifications

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -140,9 +140,9 @@
 			} );
 		});
 
-		//Dynamic live binding on newly created elements
-		$('body').on('mouseenter', '.evf-content-email-settings-inner .everest-forms-help-tooltip:not(.tooltipstered)', function(){
-			$(this).tooltipster({
+		// Dynamic live binding on newly created elements.
+		$( 'body' ).on( 'mouseenter', '.evf-content-email-settings-inner .everest-forms-help-tooltip:not(.tooltipstered)', function() {
+			$( this ).tooltipster({
 				maxWidth: 200,
 				multiple: true,
 				interactive: true,
@@ -151,7 +151,6 @@
 				updateAnimation: false,
 				restoration: 'current',
 				functionInit: function( instance, helper ) {
-					console.log('run');
 					var $origin = $( helper.origin ),
 						dataTip = $origin.attr( 'data-tip' );
 					if ( dataTip ) {
@@ -159,13 +158,12 @@
 					}
 				}
 			});
-			$(this).tooltipster('open');
-	    });
-	   	
-		$(document).on('click', '.everest-forms-email-add', function(){
-			$( '.evf-content-email-settings-inner .tooltipstered' ).tooltipster( 'destroy' );
-	   });
+			$( this ).tooltipster( 'open' );
+		});
 
+		$( document ).on('click', '.everest-forms-email-add', function(){
+			$( '.evf-content-email-settings-inner .tooltipstered' ).tooltipster( 'destroy' );
+		});
 
 	// Tooltips
 	$( document.body ).trigger( 'init_tooltips' );

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -128,6 +128,7 @@
 				position: 'bottom',
 				contentAsHTML: true,
 				updateAnimation: false,
+				restoration: 'current',
 				functionInit: function( instance, helper ) {
 					var $origin = $( helper.origin ),
 						dataTip = $origin.attr( 'data-tip' );
@@ -138,6 +139,33 @@
 				}
 			} );
 		});
+
+		//Dynamic live binding on newly created elements
+		$('body').on('mouseenter', '.evf-content-email-settings-inner .everest-forms-help-tooltip:not(.tooltipstered)', function(){
+			$(this).tooltipster({
+				maxWidth: 200,
+				multiple: true,
+				interactive: true,
+				position: 'bottom',
+				contentAsHTML: true,
+				updateAnimation: false,
+				restoration: 'current',
+				functionInit: function( instance, helper ) {
+					console.log('run');
+					var $origin = $( helper.origin ),
+						dataTip = $origin.attr( 'data-tip' );
+					if ( dataTip ) {
+						instance.content( dataTip );
+					}
+				}
+			});
+			$(this).tooltipster('open');
+	    });
+	   	
+		$(document).on('click', '.everest-forms-email-add', function(){
+			$( '.evf-content-email-settings-inner .tooltipstered' ).tooltipster( 'destroy' );
+	   });
+
 
 	// Tooltips
 	$( document.body ).trigger( 'init_tooltips' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #115 
Tooltip seems to be not working for newly created email notifications because the new notifications fields were added via cloning. Since the nodes cloned were added later to the DOM we need to consider live binding. 

If there is a better way to tackle this, changes are welcome

### How to test the changes in this Pull Request:

1. Go to Email settings->Add new Email notification
2. Check the tooltip without saving the new notifications.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->