### PR TITLE
Submit conditional process only when conditional logic is enabled

### DIFF
--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -66,7 +66,7 @@ class EVF_Shortcode_Form {
 
 		// Submit button area.
 		$conditional_id = 'evf-submit-' . $form_id;
-		if ( $form_data['settings']['submit']['connection_1']['conditional_logic_status'] === '1' ) {
+		if ( '1' === $form_data['settings']['submit']['connection_1']['conditional_logic_status'] ) {
 			$con_rules = array(
 				'conditional_option' => isset( $form_data['settings']['submit']['connection_1']['conditional_option'] ) ? $form_data['settings']['submit']['connection_1']['conditional_option'] : '',
 				'conditionals'       => isset( $form_data['settings']['submit']['connection_1']['conditionals'] ) ? $form_data['settings']['submit']['connection_1']['conditionals'] : '',

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -65,11 +65,15 @@ class EVF_Shortcode_Form {
 		$visibility_class = apply_filters( 'everest_forms_field_submit_visibility_class', array(), self::$parts, $form_data );
 
 		// Submit button area.
-		$conditional_id    = 'evf-submit-' . $form_id;
-		$con_rules         = array(
-			'conditional_option' => isset( $form_data['settings']['submit']['connection_1']['conditional_option'] ) ? $form_data['settings']['submit']['connection_1']['conditional_option'] : '',
-			'conditionals'       => isset( $form_data['settings']['submit']['connection_1']['conditionals'] ) ? $form_data['settings']['submit']['connection_1']['conditionals'] : '',
-		);
+		$conditional_id = 'evf-submit-' . $form_id;
+		if ( $form_data['settings']['submit']['connection_1']['conditional_logic_status'] === '1' ) {
+			$con_rules = array(
+				'conditional_option' => isset( $form_data['settings']['submit']['connection_1']['conditional_option'] ) ? $form_data['settings']['submit']['connection_1']['conditional_option'] : '',
+				'conditionals'       => isset( $form_data['settings']['submit']['connection_1']['conditionals'] ) ? $form_data['settings']['submit']['connection_1']['conditionals'] : '',
+			);
+		} else {
+			$con_rules = '';
+		}
 		$conditional_rules = json_encode( $con_rules );
 		echo '<div class="evf-submit-container ' . esc_attr( implode( ' ', $visibility_class ) ) . '" ' . $visible . '>';
 


### PR DESCRIPTION
This PR contains the condition to process conditional logic only if submit button conditional logic is enabled. Previously, if we set the conditional logic for submit button and disable the conditional logic for submit button. It was treated like the conditional logic is enabled.