### PR TITLE
Fix - Submit button Processing text while form is not saved

### DIFF
--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -66,7 +66,9 @@ class EVF_Shortcode_Form {
 		$visibility_class = apply_filters( 'everest_forms_field_submit_visibility_class', array(), self::$parts, $form_data );
 
 		// Check for submit button processing-text.
-		if ( ! empty( $settings['submit_button_processing_text'] ) ) {
+		if ( ! isset( $settings['submit_button_processing_text'] ) ) {
+			$process = 'data-process-text="' . esc_attr__( 'Processing&hellip;', 'everest-forms' ) . '"';
+		} elseif ( ! empty( $settings['submit_button_processing_text'] ) ) {
 			$process = 'data-process-text="' . esc_attr( $settings['submit_button_processing_text'] ) . '"';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR fixes the processing text while form submit.

Closes #176 

### How to test the changes in this Pull Request:

1. Go to the form which is built by an older version.
2. Don't EDIT or SAVE the form.
3. Preview the form or go to the page where the form is located.
4. Fill the form and submit it.
5. The form will be on the process of submitting but the button will be not in Processing.. action which is the introduced new feature in the latest version of the Everest Forms.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Processing text while form not saved
