### PR TITLE
Fix - Date and time of entry submission 

### DIFF
--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -479,7 +479,7 @@ class EVF_Form_Task {
 			'user_ip_address' => sanitize_text_field( $user_ip ),
 			'status'          => 'publish',
 			'referer'         => $_SERVER['HTTP_REFERER'],
-			'date_created'    => current_time( 'mysql' ),
+			'date_created'    => current_time( 'mysql', true ),
 		);
 
 		if ( ! $entry_data['form_id'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The current timestamp is displayed by the submission date of entry relative to the timezone set by the user in the general setting of WordPress. Previously, when the timezone was set anything but UTC-0, it displayed incorrect date/time when the entry was made.
### How to test the changes in this Pull Request:

1. Create a form and enter the data.
2. Check the submission date of the entry.
3. Change the timezone in the general setting of WordPress.
4. Check if the previous submission date changes according to the timezone selected.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Entry submission date and time of the entry when timezone is changed.
