### PR TITLE
Field choices preview fixed while removing field choices

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -384,11 +384,7 @@
 						}
 					});
 				} else {
-					var self = $( this );
-					setTimeout(function(){
-						self.closest( 'li' ).remove();
-					}, 100);
-
+					$( this ).closest( 'li' ).remove();
 					EVFPanelBuilder.choiceChange( field_id );
 				}
 			});


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR solves the bug while deleting the choice list of checkbox and radio field which was not reflecting live on preview.

### How to test the changes in this Pull Request:

1. Edit or create a form.
2. Drag the checkbox and radio field.
3. Remove the options list one by one and see the preview on admin panel.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Field choices preview fixed while removing field choices.
