### PR TITLE
Tweak - Seperate site and secret key for recaptcha v2 invisible

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -88,13 +88,13 @@
 
 	// Show/hide based on reCAPTCHA type.
 	$( 'input#everest_forms_recaptcha_type' ).change( function() {
-		var recaptcha_v2_site_key   = $( '#everest_forms_recaptcha_v2_site_key' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v2_secret_key = $( '#everest_forms_recaptcha_v2_secret_key' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v2_invisible_site_key  = $( '#everest_forms_recaptcha_v2_invisible_site_key' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v2_invisible_secret_key  = $( '#everest_forms_recaptcha_v2_invisible_secret_key' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v2_invisible  = $( '#everest_forms_recaptcha_v2_invisible' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v3_site_key   = $( '#everest_forms_recaptcha_v3_site_key' ).parents( 'tr' ).eq( 0 ),
-			recaptcha_v3_secret_key = $( '#everest_forms_recaptcha_v3_secret_key' ).parents( 'tr' ).eq( 0 );
+		var recaptcha_v2_site_key             = $( '#everest_forms_recaptcha_v2_site_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_secret_key           = $( '#everest_forms_recaptcha_v2_secret_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_invisible_site_key   = $( '#everest_forms_recaptcha_v2_invisible_site_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_invisible_secret_key = $( '#everest_forms_recaptcha_v2_invisible_secret_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_invisible            = $( '#everest_forms_recaptcha_v2_invisible' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v3_site_key             = $( '#everest_forms_recaptcha_v3_site_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v3_secret_key           = $( '#everest_forms_recaptcha_v3_secret_key' ).parents( 'tr' ).eq( 0 );
 
 		if ( $( this ).is( ':checked' ) ) {
 			if ( 'v2' === $( this ).val() ) {
@@ -110,7 +110,6 @@
 					recaptcha_v2_secret_key.show();
 				}
 				recaptcha_v2_invisible.show();
-
 				recaptcha_v3_site_key.hide();
 				recaptcha_v3_secret_key.hide();
 			} else {
@@ -125,7 +124,7 @@
 		}
 	}).change();
 
-	$('input#everest_forms_recaptcha_v2_invisible').change( function() {
+	$( 'input#everest_forms_recaptcha_v2_invisible' ).change( function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$('#everest_forms_recaptcha_v2_site_key').parents( 'tr' ).eq( 0 ).hide();
 			$('#everest_forms_recaptcha_v2_secret_key').parents( 'tr' ).eq( 0 ).hide();

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -90,24 +90,52 @@
 	$( 'input#everest_forms_recaptcha_type' ).change( function() {
 		var recaptcha_v2_site_key   = $( '#everest_forms_recaptcha_v2_site_key' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v2_secret_key = $( '#everest_forms_recaptcha_v2_secret_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_invisible_site_key  = $( '#everest_forms_recaptcha_v2_invisible_site_key' ).parents( 'tr' ).eq( 0 ),
+			recaptcha_v2_invisible_secret_key  = $( '#everest_forms_recaptcha_v2_invisible_secret_key' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v2_invisible  = $( '#everest_forms_recaptcha_v2_invisible' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v3_site_key   = $( '#everest_forms_recaptcha_v3_site_key' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v3_secret_key = $( '#everest_forms_recaptcha_v3_secret_key' ).parents( 'tr' ).eq( 0 );
 
 		if ( $( this ).is( ':checked' ) ) {
 			if ( 'v2' === $( this ).val() ) {
-				recaptcha_v2_site_key.show();
-				recaptcha_v2_secret_key.show();
+				if( $( '#everest_forms_recaptcha_v2_invisible' ).is(':checked') ) {
+					recaptcha_v2_site_key.hide();
+					recaptcha_v2_secret_key.hide();
+					recaptcha_v2_invisible_site_key.show();
+					recaptcha_v2_invisible_secret_key.show();
+				} else {
+					recaptcha_v2_invisible_site_key.hide();
+					recaptcha_v2_invisible_secret_key.hide();
+					recaptcha_v2_site_key.show();
+					recaptcha_v2_secret_key.show();
+				}
 				recaptcha_v2_invisible.show();
+
 				recaptcha_v3_site_key.hide();
 				recaptcha_v3_secret_key.hide();
 			} else {
 				recaptcha_v2_site_key.hide();
 				recaptcha_v2_secret_key.hide();
 				recaptcha_v2_invisible.hide();
+				recaptcha_v2_invisible_site_key.hide();
+				recaptcha_v2_invisible_secret_key.hide();
 				recaptcha_v3_site_key.show();
 				recaptcha_v3_secret_key.show();
 			}
+		}
+	}).change();
+
+	$('input#everest_forms_recaptcha_v2_invisible').change( function() {
+		if ( $( this ).is( ':checked' ) ) {
+			$('#everest_forms_recaptcha_v2_site_key').parents( 'tr' ).eq( 0 ).hide();
+			$('#everest_forms_recaptcha_v2_secret_key').parents( 'tr' ).eq( 0 ).hide();
+			$('#everest_forms_recaptcha_v2_invisible_site_key').parents( 'tr' ).eq( 0 ).show();
+			$('#everest_forms_recaptcha_v2_invisible_secret_key').parents( 'tr' ).eq( 0 ).show();
+		} else {
+			$('#everest_forms_recaptcha_v2_site_key').parents( 'tr' ).eq( 0 ).show();
+			$('#everest_forms_recaptcha_v2_secret_key').parents( 'tr' ).eq( 0 ).show();
+			$('#everest_forms_recaptcha_v2_invisible_site_key').parents( 'tr' ).eq( 0 ).hide();
+			$('#everest_forms_recaptcha_v2_invisible_secret_key').parents( 'tr' ).eq( 0 ).hide();
 		}
 	}).change();
 

--- a/includes/admin/settings/class-evf-settings-recaptcha.php
+++ b/includes/admin/settings/class-evf-settings-recaptcha.php
@@ -34,7 +34,9 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 	 */
 	public function get_settings() {
 		$recaptcha_type = get_option( 'everest_forms_recaptcha_type', 'v2' );
-		$settings       = apply_filters(
+		$invisible      = get_option( 'everest_forms_recaptcha_v2_invisible', 'no' );
+		echo '<pre>' . print_r( $invisible, true ) . '</pre>';
+		$settings = apply_filters(
 			'everest_forms_recaptcha_settings',
 			array(
 				array(
@@ -63,7 +65,7 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 					/* translators: %1$s - Google reCAPTCHA docs url */
 					'desc'       => sprintf( __( 'Please enter your site key for your reCAPTCHA v2. <a href="%1$s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.wpeverest.com/docs/everest-forms/tutorials/how-to-integrate-google-recaptcha/' ) ),
 					'id'         => 'everest_forms_recaptcha_v2_site_key',
-					'is_visible' => 'v2' === $recaptcha_type,
+					'is_visible' => 'v2' === $recaptcha_type && 'no' === $invisible,
 					'default'    => '',
 					'desc_tip'   => true,
 				),
@@ -73,7 +75,27 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 					/* translators: %1$s - Google reCAPTCHA docs url */
 					'desc'       => sprintf( __( 'Please enter your secret key for your reCAPTCHA v2. <a href="%1$s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.wpeverest.com/docs/everest-forms/tutorials/how-to-integrate-google-recaptcha/' ) ),
 					'id'         => 'everest_forms_recaptcha_v2_secret_key',
-					'is_visible' => 'v2' === $recaptcha_type,
+					'is_visible' => 'v2' === $recaptcha_type && 'no' === $invisible,
+					'default'    => '',
+					'desc_tip'   => true,
+				),
+				array(
+					'title'      => __( 'Site Key', 'everest-forms' ),
+					'type'       => 'text',
+					/* translators: %1$s - Google reCAPTCHA docs url */
+					'desc'       => sprintf( __( 'Please enter your site key for your reCAPTCHA v2. <a href="%1$s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.wpeverest.com/docs/everest-forms/tutorials/how-to-integrate-google-recaptcha/' ) ),
+					'id'         => 'everest_forms_recaptcha_v2_invisible_site_key',
+					'is_visible' => 'yes' === $invisible,
+					'default'    => '',
+					'desc_tip'   => true,
+				),
+				array(
+					'title'      => __( 'Secret Key', 'everest-forms' ),
+					'type'       => 'text',
+					/* translators: %1$s - Google reCAPTCHA docs url */
+					'desc'       => sprintf( __( 'Please enter your secret key for your reCAPTCHA v2. <a href="%1$s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.wpeverest.com/docs/everest-forms/tutorials/how-to-integrate-google-recaptcha/' ) ),
+					'id'         => 'everest_forms_recaptcha_v2_invisible_secret_key',
+					'is_visible' => 'yes' === $invisible,
 					'default'    => '',
 					'desc_tip'   => true,
 				),

--- a/includes/admin/settings/class-evf-settings-recaptcha.php
+++ b/includes/admin/settings/class-evf-settings-recaptcha.php
@@ -35,8 +35,7 @@ class EVF_Settings_reCAPTCHA extends EVF_Settings_Page {
 	public function get_settings() {
 		$recaptcha_type = get_option( 'everest_forms_recaptcha_type', 'v2' );
 		$invisible      = get_option( 'everest_forms_recaptcha_v2_invisible', 'no' );
-		echo '<pre>' . print_r( $invisible, true ) . '</pre>';
-		$settings = apply_filters(
+		$settings       = apply_filters(
 			'everest_forms_recaptcha_settings',
 			array(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR includes the changes in reCaptcha. Now there will be separate site and secret key for reCaptcha version 2 checkbox and invisible. 

### How to test the changes in this Pull Request:

1. Go to Settings of Everest Forms.
2. Go to reCaptcha tab and see the changes.


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - Separate site and secret key for recaptcha v2 invisible

