### PR TITLE
Entry warning fixed

### DIFF
--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -442,11 +442,11 @@ class EVF_Form_Task {
 			$emails->__set( 'from_name', $email['sender_name'] );
 			$emails->__set( 'from_address', $email['sender_address'] );
 			$emails->__set( 'reply_to', $email['reply_to'] );
-			if($entry_id) {
-				$emails->__set('attachments', apply_filters('everest_forms_email_file_attachments', $attachment, $entry, $form_data, 'entry-email', $connection_id, $entry_id));
-			} else {
-				return;
+
+			if( $entry_id ) {
+				$emails->__set( 'attachments', apply_filters('everest_forms_email_file_attachments', $attachment, $entry, $form_data, 'entry-email', $connection_id, $entry_id ));
 			}
+
 			// Maybe include Cc and Bcc email addresses.
 			if ( 'yes' === get_option( 'everest_forms_enable_email_copies' ) ) {
 				if ( ! empty( $notification['evf_carboncopy'] ) ) {

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -311,20 +311,20 @@ class EVF_Form_Task {
 		$settings = $this->form_data['settings'];
 		if ( isset( $settings['redirect_to'] ) && '1' === $settings['redirect_to'] ) {
 			?>
-				<script>
-				var redirect = '<?php echo get_permalink( $settings['custom_page'] ); ?>';
-				window.setTimeout( function () {
-					window.location.href = redirect;
-				})
-				</script>
+			<script>
+                var redirect = '<?php echo get_permalink( $settings['custom_page'] ); ?>';
+                window.setTimeout( function () {
+                    window.location.href = redirect;
+                })
+			</script>
 			<?php
 		} elseif ( isset( $settings['redirect_to'] ) && '2' == $settings['redirect_to'] ) {
 			?>
 			<script>
-				window.setTimeout( function () {
-					window.location.href = '<?php echo $settings['external_url']; ?>';
-				})
-				</script>
+                window.setTimeout( function () {
+                    window.location.href = '<?php echo $settings['external_url']; ?>';
+                })
+			</script>
 			<?php
 		}
 
@@ -442,8 +442,11 @@ class EVF_Form_Task {
 			$emails->__set( 'from_name', $email['sender_name'] );
 			$emails->__set( 'from_address', $email['sender_address'] );
 			$emails->__set( 'reply_to', $email['reply_to'] );
-			$emails->__set( 'attachments', apply_filters( 'everest_forms_email_file_attachments', $attachment, $entry, $form_data, 'entry-email', $connection_id, $entry_id ) );
-
+			if($entry_id) {
+				$emails->__set('attachments', apply_filters('everest_forms_email_file_attachments', $attachment, $entry, $form_data, 'entry-email', $connection_id, $entry_id));
+			} else {
+				return;
+			}
 			// Maybe include Cc and Bcc email addresses.
 			if ( 'yes' === get_option( 'everest_forms_enable_email_copies' ) ) {
 				if ( ! empty( $notification['evf_carboncopy'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
When the pdf submission addon is activated and the disable storing entry information is checked, a error is thrown when form is submitted which is fixed by handling entry_id conditionally.

### How to test the changes in this Pull Request:

1. Activate the Everest Form PDF Submission addon.
2. Navigate to the Everest Form form builder settings and disable storing entry information. 
3. Fill up the form, No errors will be shown after submitting the form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Entry form submission warning
