### PR TITLE
Fix accessing curl arr index warning due to likely deprecation [PHP5.6]

### DIFF
--- a/includes/evf-formatting-functions.php
+++ b/includes/evf-formatting-functions.php
@@ -316,9 +316,9 @@ if ( ! function_exists( 'evf_rgb_from_hex' ) ) {
 		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
 
 		$rgb      = array();
-		$rgb['R'] = hexdec( $color{0} . $color{1} );
-		$rgb['G'] = hexdec( $color{2} . $color{3} );
-		$rgb['B'] = hexdec( $color{4} . $color{5} );
+		$rgb['R'] = hexdec( $color[0] . $color[1] );
+		$rgb['G'] = hexdec( $color[2] . $color[3] );
+		$rgb['B'] = hexdec( $color[4] . $color[5] );
 
 		return $rgb;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] I have followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Code follows the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
* [x] Have found no other PRs addressing this.
<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Fixes:

The deprecation note states making the accessing of array indices consistent. This PR aims to conform to them, while making sure PHP 5.6.22 still supports them.

![image](https://user-images.githubusercontent.com/30156167/70295806-52727e80-1810-11ea-8041-fe0d405a2f98.png)

_Tested with version PHP 7.4.0_

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Use brackets instead of braces to avoid deprecation notices in PHP 5.6
