### PR TITLE
Tweak - Sorting with template plan types

### DIFF
--- a/assets/js/admin/form-template-controller.js
+++ b/assets/js/admin/form-template-controller.js
@@ -1,0 +1,134 @@
+/*
+   Since v1.6.0
+   global evf_template_controller
+   Controls the form templates elements
+*/
+jQuery( function( $ ) {
+
+	/**
+	 * Init actions.
+	 */
+	var  evf_template_controller = {
+		all     : '#evf-form-all',
+		basic   : '#evf-form-basic',
+		pro     : '#evf-form-pro',
+		results : null,
+		url : evf_templates.evf_template_url,
+
+		init: function() {
+				evf_template_controller.latch_hooks();
+				evf_template_controller.fetch_ajax();
+		},
+
+		latch_hooks: function() {
+			$( document ).ready(function() {
+				$( evf_template_controller.all ).click( function() {
+					evf_template_controller.sort_all( this );
+				});
+				$( evf_template_controller.basic ).click(function() {
+					evf_template_controller.sort_basic( this );
+				});
+				$( evf_template_controller.pro ).click(function() {
+					evf_template_controller.sort_pro( this );
+				});
+			});
+		},
+
+		sort_all: function( el ) {
+			evf_template_controller.class_update( $(el) );
+			evf_template_controller.render_results( evf_template_controller.results, 'all' );
+		},
+
+		sort_basic: function( el ) {
+			evf_template_controller.class_update( $(el) );
+			evf_template_controller.render_results( evf_template_controller.results, 'free' );
+		},
+
+		sort_pro: function( el ) {
+			evf_template_controller.class_update( $(el) );
+			evf_template_controller.render_results( evf_template_controller.results, 'pro' );
+		},
+
+
+		class_update: function( $el ) {
+			$( '.everest-forms-tab-nav' ).removeClass( 'active' );
+			$el.parent().addClass( 'active' );
+		},
+
+		fetch_ajax: function() {
+
+			// Fetch results once, then reuse them.
+			try {
+				$.ajax( evf_template_controller.url,
+					{
+						type: 'GET',
+						jsonp: false,
+						dataType: 'json'
+					})
+					.success( function( data ) {
+						window.results = data.templates;
+						evf_template_controller.results = data.templates;
+					})
+					.error( function() {
+
+					});
+			} catch( err ) {
+				return false;
+			}
+		},
+
+		render_results: function( template, allow ) {
+			var el_to_append = $('.evf-setup-templates'),
+				error = '<div id="message" class="error"><p>' + evf_templates.i18n_pro_error_f + '</p></div>';
+
+			if ( ! template ) {
+
+				$('#message').remove();
+				el_to_append.append( error );
+				return;
+			}
+
+			$('.everest-forms-form-template').html('');
+			template.forEach( function( tuple ) {
+				var toAppend  = '',
+					plan      = ( tuple.plan.includes('free') )? 'free' : 'pro',
+					data_plan = $( '.evf-setup-templates' ).data( 'license-type' );
+
+				if ( 'all' === allow || 'blank' === tuple.slug ) {
+					toAppend = evf_template_controller.template_snippet( tuple, plan, data_plan );
+				} else if ( plan === allow ) {
+					toAppend = evf_template_controller.template_snippet( tuple, plan, data_plan );
+				}
+
+				el_to_append.append( toAppend );
+			});
+		},
+
+		template_snippet: function( template, plan, data_plan ) {
+			var html  = '',
+				modal = 'evf-template-select';
+				data_plan = ( '' === data_plan ) ? 'free' : data_plan;
+
+			if ( 'free' === data_plan && ! template.plan.includes(data_plan) ) {
+				modal = 'upgrade-modal';
+			}
+
+			html += '<div class="everest-forms-template-wrap evf-template" id="everest-forms-template-' + template.slug + '" data-plan="' + plan + '">';
+			html += '<figure class="everest-forms-screenshot" ';
+			html +=	'data-template-name-raw="' + template.title + '" data-template="' + template.slug + '" data-template-name="' + template.title + ' template">';
+			html +=	'<img src=" ' + template.image +' ">';
+			html += '<div class="form-action"><a href="#" class="everest-forms-btn everest-forms-btn-primary ' + modal +'" data-licence-plan="' + data_plan + '" data-template-name-raw="' + template.title + '" data-template-name="' + template.title + ' template" data-template="' + template.slug + '">' + evf_templates.i18n_get_started + '</a>';
+			html += '<a href="#" class="everest-forms-btn everest-forms-btn-secondary">' + evf_templates.i18n_get_preview + '</a></div>';
+
+			if ( ! template.plan.includes('free') ) {
+				html +=	'<span class="everest-forms-badge everest-forms-badge-success">' + evf_templates.i18n_pro_feature + '</span>';
+			}
+
+			html += '</figure><div class="everest-forms-form-id-container">';
+			html +=	'<a class="everest-forms-template-name ' + modal + '" href="#" data-template-name-raw="' + template.title + '" data-licence-plan="' + data_plan + '" data-template="' + template.slug + '" data-template-name="' + template.title + ' template">' + template.title + '</a></div>';
+			return html;
+		}
+	};
+
+	evf_template_controller.init();
+});

--- a/includes/admin/class-evf-admin-assets.php
+++ b/includes/admin/class-evf-admin-assets.php
@@ -82,6 +82,18 @@ class EVF_Admin_Assets {
 		wp_register_script( 'evf-clipboard', EVF()->plugin_url() . '/assets/js/admin/evf-clipboard' . $suffix . '.js', array( 'jquery' ), EVF_VERSION, true );
 		wp_register_script( 'selectWoo', EVF()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.4', true );
 		wp_register_script( 'evf-enhanced-select', EVF()->plugin_url() . '/assets/js/admin/evf-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), EVF_VERSION, true );
+		wp_register_script( 'evf-template-controller', EVF()->plugin_url() . '/assets/js/admin/form-template-controller' . $suffix . '.js', array( 'jquery' ), EVF_VERSION );
+		wp_localize_script(
+			'evf-template-controller',
+			'evf_templates',
+			array(
+				'evf_template_url' => 'https://raw.githubusercontent.com/wpeverest/extensions-json/template/everest-forms/templates/all_templates.json',
+				'i18n_get_started' => _x( 'Get Started', 'template controller: get started button', 'everest-forms' ),
+				'i18n_get_preview' => _x( 'Preview', 'template controller: preview button', 'everest-forms' ),
+				'i18n_pro_feature' => _x( 'Pro', 'template controller: pro version span', 'everest-forms' ),
+				'i18n_pro_error_f' => _x( 'Please check your internet connection.', 'template controller: pro version error', 'everest-forms' ),
+			)
+		);
 		wp_localize_script(
 			'evf-enhanced-select',
 			'evf_enhanced_select_params',

--- a/includes/admin/views/html-admin-page-builder-setup.php
+++ b/includes/admin/views/html-admin-page-builder-setup.php
@@ -22,10 +22,10 @@ $core_templates = apply_filters(
 		),
 		)
 	);
+	wp_enqueue_script( 'evf-template-controller' );
 	delete_transient( 'evf_template_section' );
 	delete_transient( 'evf_template_sections' );
 ?>
-
 <div class ="wrap everest-forms">
 	<div class="evf-loading"></div>
 	<div class="everest-forms-setup">
@@ -40,15 +40,18 @@ $core_templates = apply_filters(
 			<nav class="everest-forms-tab">
 				<ul>
 					<li class="everest-forms-tab-nav active">
-						<a href="#" class="everest-forms-tab-nav-link"><?php _e( 'Free', 'everest-forms' ); ?></a>
+						<a href="#" id="evf-form-all" class="everest-forms-tab-nav-link"><?php _e( 'All', 'everest-forms' ); ?></a>
 					</li>
 					<li class="everest-forms-tab-nav">
-						<a href="#" class="everest-forms-tab-nav-link"><?php _e( 'Premium', 'everest-forms' ); ?></a>
+						<a href="#" id="evf-form-basic" class="everest-forms-tab-nav-link"><?php _e( 'Free', 'everest-forms' ); ?></a>
+					</li>
+					<li class="everest-forms-tab-nav">
+						<a href="#" id="evf-form-pro" class="everest-forms-tab-nav-link"><?php _e( 'Premium', 'everest-forms' ); ?></a>
 					</li>
 				</ul>
 			</nav>
 		</div>
-		<div class="everest-forms-form-template evf-setup-templates">
+		<div class="everest-forms-form-template evf-setup-templates" data-license-type="<?php echo esc_attr( $license_plan )?>">
 			<?php
 			if ( empty( $templates ) ) {
 				$error_string = esc_html("Please check your internet connection.", 'everest-forms' );
@@ -82,7 +85,7 @@ $core_templates = apply_filters(
 							<?php endif; ?>
 						</figure>
 						<div class="everest-forms-form-id-container">
-							<a class="everest-forms-template-name evf-template-select" href="#" data-licence-plan="<?php echo esc_attr( $license_plan ); ?>" data-template-name-raw="<?php echo esc_attr( $template->title ); ?>" data-template="<?php echo esc_attr( $template->slug ); ?>" data-template-name="<?php printf( _x( '%s template', 'Template name', 'everest-forms' ), esc_attr( $template->title ) ); ?>"><?php echo esc_attr( $template->title ); ?></a>
+							<a class="everest-forms-template-name <?php echo esc_attr( $upgrade_class ); ?>" href="#" data-licence-plan="<?php echo esc_attr( $license_plan ); ?>" data-template-name-raw="<?php echo esc_attr( $template->title ); ?>" data-template="<?php echo esc_attr( $template->slug ); ?>" data-template-name="<?php printf( _x( '%s template', 'Template name', 'everest-forms' ), esc_attr( $template->title ) ); ?>"><?php echo esc_attr( $template->title ); ?></a>
 						</div>
 					</div>
 				<?php endforeach;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows template formats filtering on the add new profile.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Head on over to Add new feature
2. Sorting may be done via All, Free, and Pro
3. Displays only the template with the respective plan PLUS add new form (default)

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Allows easy and dynamic sorting of the various templates based on their plans
