### PR TITLE
Fix - Specific form submission notice display in another.

### DIFF
--- a/includes/evf-notice-functions.php
+++ b/includes/evf-notice-functions.php
@@ -132,9 +132,8 @@ function evf_print_notices( $form_data = array() ) {
 	$all_notices  = EVF()->session->get( 'evf_notices', array() );
 	$notice_types = apply_filters( 'everest_forms_notice_types', array( 'error', 'success', 'notice' ) );
 
-	// Escapes in case of multiple forms to find out the correct form to post notices on.
+	// Skips notice print if it isn't the right form.
 	if ( isset( $_REQUEST['everest_forms']['id'] ) && ( (int) $form_id !== (int) $_REQUEST['everest_forms']['id'] ) ) {
-		// If it doesn't align with the right form, don't proceed
 		return;
 	}
 

--- a/includes/evf-notice-functions.php
+++ b/includes/evf-notice-functions.php
@@ -132,6 +132,12 @@ function evf_print_notices( $form_data = array() ) {
 	$all_notices  = EVF()->session->get( 'evf_notices', array() );
 	$notice_types = apply_filters( 'everest_forms_notice_types', array( 'error', 'success', 'notice' ) );
 
+	// Escapes in case of multiple forms to find out the correct form to post notices on.
+	if ( isset( $_REQUEST['everest_forms']['id'] ) && ( (int) $form_id !== (int) $_REQUEST['everest_forms']['id'] ) ) {
+		// If it doesn't align with the right form, don't proceed
+		return;
+	}
+
 	foreach ( $notice_types as $notice_type ) {
 		if ( evf_notice_count( $notice_type ) > 0 ) {
 			foreach ( $all_notices[ $notice_type ] as $key => $message ) {


### PR DESCRIPTION
### Closes  #266 

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Aims to fix the unlisted issue that is multi forms in a single page causes.

### Changes in this Pull Request:

1. Makes the notice appear before the form shortcode
2. Makes sure the notice appears only once
3. Allows clearing of the session for notice once it has served its purpose

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Successfully ran tests with your changes locally - Might need more testing/review
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Change log entry

> Fix - Specific form submission notice display in another.