### PR TITLE
Fix - Error thrown for star rating field when using smart tags.

### DIFF
--- a/includes/class-evf-smart-tags.php
+++ b/includes/class-evf-smart-tags.php
@@ -80,6 +80,8 @@ class EVF_Smart_Tags {
 						} elseif ( in_array( $value['type'], array( 'checkbox', 'payment-checkbox' ), true ) ) {
 							$value = implode( ', ', $value['label'] );
 						}
+					} elseif ( isset( $value['number_of_rating'], $value['value'] ) ) {
+						$value = (string) $value['value'] . '/' . (string) $value['number_of_rating'];
 					}
 
 					$content = str_replace( '{field_id="' . $field_id . '"}', $value, $content );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix - Error thrown for star rating field when using smart tags.

### How to test the changes in this Pull Request:

1. Creating a new rating field
2. Enable logging, and enclose the smart tag function in a try catch block, and log the exceptions.
3. Observe no logs, notices thrown in the debug enabled environment

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error thrown for star rating field when using smart tags.
