### PR TITLE
Fix - conditional logic fix for checkbox/radio

### DIFF
--- a/includes/fields/class-evf-field-checkbox.php
+++ b/includes/fields/class-evf-field-checkbox.php
@@ -192,7 +192,7 @@ class EVF_Field_Checkbox extends EVF_Form_Fields {
 					'name'  => "everest_forms[form_fields][{$field_id}][]",
 					'value' => $value,
 				),
-				'class'     => array(),
+				'class'     => array( 'input-text' ),
 				'data'      => array(),
 				'id'        => "evf-{$form_id}-field_{$field_id}_{$key}",
 				'image'     => isset( $choice['image'] ) ? $choice['image'] : '',

--- a/includes/fields/class-evf-field-radio.php
+++ b/includes/fields/class-evf-field-radio.php
@@ -163,7 +163,7 @@ class EVF_Field_Radio extends EVF_Form_Fields {
 					'name'  => "everest_forms[form_fields][{$field_id}]",
 					'value' => isset( $field['show_values'] ) ? $choice['value'] : $choice['label'],
 				),
-				'class'     => array(),
+				'class'     => array( 'input-text' ),
 				'data'      => array(),
 				'id'        => "evf-{$form_id}-field_{$field_id}_{$key}",
 				'image'     => isset( $choice['image'] ) ? $choice['image'] : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The radio and checkbox fields were having their conditional logic broken, thus it was prudent to get them working again. The issue was due to the class name not having 'input-text', so the javascript wasn't able to fire the events for show/hide on right conditional. This PR intends to address that issue.

Closes # .

### How to test the changes in this Pull Request:

1. Introduce Show/Hide Conditional logic to the base field components radio and checkbox.
2. Notice the show/hide upon right conditional are being met.
3. Observe that the fix is in order.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - conditional logic fix for checkbox/radio.
