### PR TITLE
Log file cleanup/purge

### DIFF
--- a/includes/class-evf-install.php
+++ b/includes/class-evf-install.php
@@ -65,7 +65,7 @@ class EVF_Install {
 		),
 		'1.6.0' => array(
 			'evf_update_160_db_version',
-		)
+		),
 	);
 
 	/**
@@ -307,8 +307,10 @@ class EVF_Install {
 	 * Create cron jobs (clear them first).
 	 */
 	private static function create_cron_jobs() {
+		wp_clear_scheduled_hook( 'everest_forms_cleanup_logs' );
 		wp_clear_scheduled_hook( 'everest_forms_cleanup_sessions' );
-		wp_schedule_event( time(), 'twicedaily', 'everest_forms_cleanup_sessions' );
+		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'everest_forms_cleanup_logs' );
+		wp_schedule_event( time() + ( 6 * HOUR_IN_SECONDS ), 'twicedaily', 'everest_forms_cleanup_sessions' );
 	}
 
 	/**

--- a/includes/class-evf-logger.php
+++ b/includes/class-evf-logger.php
@@ -1,16 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
 /**
  * Provides logging capabilities for debugging purposes.
  *
- * @class          EVF_Logger
- * @version        1.0.0
- * @package        EverestForms/Classes
- * @category       Class
- * @author         WPEverest
+ * @class   EVF_Logger
+ * @version 1.0.0
+ * @package EverestForms/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * EVF_Logger class
  */
 class EVF_Logger implements EVF_Logger_Interface {
 
@@ -31,12 +31,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	/**
 	 * Constructor for the logger.
 	 *
-	 * @param array $handlers Optional. Array of log handlers. If $handlers is not provided,
-	 *     the filter 'everest_forms_register_log_handlers' will be used to define the handlers.
-	 *     If $handlers is provided, the filter will not be applied and the handlers will be
-	 *     used directly.
-	 * @param string $threshold Optional. Define an explicit threshold. May be configured
-	 *     via  EVF_LOG_THRESHOLD. By default, all logs will be processed.
+	 * @param array  $handlers Optional. Array of log handlers. If $handlers is not provided, the filter 'everest_forms_register_log_handlers' will be used to define the handlers. If $handlers is provided, the filter will not be applied and the handlers will be used directly.
+	 * @param string $threshold Optional. Define an explicit threshold. May be configured via  EVF_LOG_THRESHOLD. By default, all logs will be processed.
 	 */
 	public function __construct( $handlers = null, $threshold = null ) {
 		if ( null === $handlers ) {
@@ -48,7 +44,7 @@ class EVF_Logger implements EVF_Logger_Interface {
 		if ( ! empty( $handlers ) && is_array( $handlers ) ) {
 			foreach ( $handlers as $handler ) {
 				$implements = class_implements( $handler );
-				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'EVF_Log_Handler_Interface', $implements ) ) {
+				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'EVF_Log_Handler_Interface', $implements, true ) ) {
 					$register_handlers[] = $handler;
 				} else {
 					evf_doing_it_wrong(
@@ -80,7 +76,7 @@ class EVF_Logger implements EVF_Logger_Interface {
 	/**
 	 * Determine whether to handle or ignore log.
 	 *
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @return bool True if the log should be handled.
 	 */
 	protected function should_handle( $level ) {
@@ -96,15 +92,21 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 * This is not the preferred method for adding log messages. Please use log() or any one of
 	 * the level methods (debug(), info(), etc.). This method may be deprecated in the future.
 	 *
-	 * @param string $handle
-	 * @param string $message
-	 * @param string $level
-	 *
+	 * @param string $handle File handle.
+	 * @param string $message Message to log.
+	 * @param string $level Logging level.
 	 * @return bool
 	 */
 	public function add( $handle, $message, $level = EVF_Log_Levels::NOTICE ) {
 		$message = apply_filters( 'everest_forms_logger_add_message', $message, $handle );
-		$this->log( $level, $message, array( 'source' => $handle, '_legacy' => true ) );
+		$this->log(
+			$level,
+			$message,
+			array(
+				'source'  => $handle,
+				'_legacy' => true,
+			)
+		);
 		evf_do_deprecated_action( 'everest_forms_log_add', array( $handle, $message ), '1.2', 'This action has been deprecated with no alternative.' );
 		return true;
 	}
@@ -131,11 +133,10 @@ class EVF_Logger implements EVF_Logger_Interface {
 		}
 
 		if ( $this->should_handle( $level ) ) {
-			$timestamp = current_time( 'timestamp' );
-			$message   = apply_filters( 'everest_forms_logger_log_message', $message, $level, $context );
+			$message = apply_filters( 'everest_forms_logger_log_message', $message, $level, $context );
 
 			foreach ( $this->handlers as $handler ) {
-				$handler->handle( $timestamp, $level, $message, $context );
+				$handler->handle( time(), $level, $message, $context );
 			}
 		}
 	}
@@ -147,8 +148,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function emergency( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::EMERGENCY, $message, $context );
@@ -162,8 +163,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function alert( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::ALERT, $message, $context );
@@ -177,8 +178,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function critical( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::CRITICAL, $message, $context );
@@ -192,8 +193,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function error( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::ERROR, $message, $context );
@@ -209,8 +210,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function warning( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::WARNING, $message, $context );
@@ -223,8 +224,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function notice( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::NOTICE, $message, $context );
@@ -238,8 +239,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function info( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::INFO, $message, $context );
@@ -252,8 +253,8 @@ class EVF_Logger implements EVF_Logger_Interface {
 	 *
 	 * @see EVF_Logger::log
 	 *
-	 * @param string $message
-	 * @param array  $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function debug( $message, $context = array() ) {
 		$this->log( EVF_Log_Levels::DEBUG, $message, $context );
@@ -262,14 +263,34 @@ class EVF_Logger implements EVF_Logger_Interface {
 	/**
 	 * Clear entries from chosen file.
 	 *
-	 * @deprecated 1.2.0
-	 *
-	 * @param string $handle
+	 * @param string $source Source/handle to clear.
 	 * @return bool
 	 */
-	public function clear( $handle ) {
-		evf_deprecated_function( 'EVF_Logger::clear', '1.2', 'EVF_Log_Handler_File::clear' );
-		$handler = new EVF_Log_Handler_File();
-		return $handler->clear( $handle );
+	public function clear( $source = '' ) {
+		if ( ! $source ) {
+			return false;
+		}
+		foreach ( $this->handlers as $handler ) {
+			if ( is_callable( array( $handler, 'clear' ) ) ) {
+				$handler->clear( $source );
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Clear all logs older than a defined number of days. Defaults to 30 days.
+	 *
+	 * @since 1.6.2
+	 */
+	public function clear_expired_logs() {
+		$days      = absint( apply_filters( 'everest_forms_logger_days_to_retain_logs', 30 ) );
+		$timestamp = strtotime( "-{$days} days" );
+
+		foreach ( $this->handlers as $handler ) {
+			if ( is_callable( array( $handler, 'delete_logs_before_timestamp' ) ) ) {
+				$handler->delete_logs_before_timestamp( $timestamp );
+			}
+		}
 	}
 }

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1964,3 +1964,17 @@ function evf_string_translation( $form_id, $field_id, $variable ) {
 
 	return $variable;
 }
+
+/**
+ * Trigger logging cleanup using the logging class.
+ *
+ * @since 1.6.2
+ */
+function evf_cleanup_logs() {
+	$logger = evf_get_logger();
+
+	if ( is_callable( array( $logger, 'clear_expired_logs' ) ) ) {
+		$logger->clear_expired_logs();
+	}
+}
+add_action( 'everest_forms_cleanup_logs', 'evf_cleanup_logs' );

--- a/includes/log-handlers/class-evf-log-handler-file.php
+++ b/includes/log-handlers/class-evf-log-handler-file.php
@@ -43,12 +43,11 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	 * @param int $log_size_limit Optional. Size limit for log files. Default 5mb.
 	 */
 	public function __construct( $log_size_limit = null ) {
-
 		if ( null === $log_size_limit ) {
 			$log_size_limit = 5 * 1024 * 1024;
 		}
 
-		$this->log_size_limit = $log_size_limit;
+		$this->log_size_limit = apply_filters( 'everest_forms_log_file_size_limit', $log_size_limit );
 
 		add_action( 'plugins_loaded', array( $this, 'write_cached_logs' ) );
 	}
@@ -61,7 +60,7 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	public function __destruct() {
 		foreach ( $this->handles as $handle ) {
 			if ( is_resource( $handle ) ) {
-				fclose( $handle );
+				fclose( $handle ); // @codingStandardsIgnoreLine
 			}
 		}
 	}
@@ -69,11 +68,11 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Handle a log entry.
 	 *
-	 * @param int $timestamp Log timestamp.
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
+	 * @param int    $timestamp Log timestamp.
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @param string $message Log message.
-	 * @param array $context {
-	 *     Additional information for log handlers.
+	 * @param array  $context {
+	 *      Additional information for log handlers.
 	 *
 	 *     @type string $source Optional. Determines log file to write to. Default 'log'.
 	 *     @type bool $_legacy Optional. Default false. True to use outdated log format
@@ -83,7 +82,6 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	 * @return bool False if value was not handled and true if value was handled.
 	 */
 	public function handle( $timestamp, $level, $message, $context ) {
-
 		if ( isset( $context['source'] ) && $context['source'] ) {
 			$handle = $context['source'];
 		} else {
@@ -98,15 +96,14 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Builds a log entry text from timestamp, level and message.
 	 *
-	 * @param int $timestamp Log timestamp.
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
+	 * @param int    $timestamp Log timestamp.
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @param string $message Log message.
-	 * @param array $context Additional information for log handlers.
+	 * @param array  $context Additional information for log handlers.
 	 *
 	 * @return string Formatted log entry.
 	 */
 	protected static function format_entry( $timestamp, $level, $message, $context ) {
-
 		if ( isset( $context['_legacy'] ) && true === $context['_legacy'] ) {
 			if ( isset( $context['source'] ) && $context['source'] ) {
 				$handle = $context['source'];
@@ -114,8 +111,8 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 				$handle = 'log';
 			}
 			$message = apply_filters( 'everest_forms_logger_add_message', $message, $handle );
-			$time = date_i18n( 'm-d-Y @ H:i:s' );
-			$entry = "{$time} - {$message}";
+			$time    = date_i18n( 'm-d-Y @ H:i:s' );
+			$entry   = "{$time} - {$message}";
 		} else {
 			$entry = parent::format_entry( $timestamp, $level, $message, $context );
 		}
@@ -139,15 +136,17 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 
 		if ( $file ) {
 			if ( ! file_exists( $file ) ) {
-				$temphandle = @fopen( $file, 'w+' );
-				@fclose( $temphandle );
+				$temphandle = @fopen( $file, 'w+' ); // @codingStandardsIgnoreLine
+				@fclose( $temphandle ); // @codingStandardsIgnoreLine
 
 				if ( defined( 'FS_CHMOD_FILE' ) ) {
-					@chmod( $file, FS_CHMOD_FILE );
+					@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine
 				}
 			}
 
-			if ( $resource = @fopen( $file, $mode ) ) {
+			$resource = @fopen( $file, $mode ); // @codingStandardsIgnoreLine
+
+			if ( $resource ) {
 				$this->handles[ $handle ] = $resource;
 				return true;
 			}
@@ -169,14 +168,14 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Close a handle.
 	 *
-	 * @param string $handle
+	 * @param string $handle Log handle.
 	 * @return bool success
 	 */
 	protected function close( $handle ) {
 		$result = false;
 
 		if ( $this->is_open( $handle ) ) {
-			$result = fclose( $this->handles[ $handle ] );
+			$result = fclose( $this->handles[ $handle ] ); // @codingStandardsIgnoreLine
 			unset( $this->handles[ $handle ] );
 		}
 
@@ -186,8 +185,8 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Add a log entry to chosen file.
 	 *
-	 * @param string $entry Log entry text
-	 * @param string $handle Log entry handle
+	 * @param string $entry Log entry text.
+	 * @param string $handle Log entry handle.
 	 *
 	 * @return bool True if write was successful.
 	 */
@@ -199,7 +198,7 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 		}
 
 		if ( $this->open( $handle ) && is_resource( $this->handles[ $handle ] ) ) {
-			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL );
+			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL ); // @codingStandardsIgnoreLine
 		} else {
 			$this->cache_log( $entry, $handle );
 		}
@@ -210,7 +209,7 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Clear entries from chosen file.
 	 *
-	 * @param string $handle
+	 * @param string $handle Log handle.
 	 *
 	 * @return bool
 	 */
@@ -236,22 +235,23 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Remove/delete the chosen file.
 	 *
-	 * @param string $handle
+	 * @param string $handle Log handle.
 	 *
 	 * @return bool
 	 */
 	public function remove( $handle ) {
 		$removed = false;
-		$file    = self::get_log_file_path( $handle );
+		$logs    = $this->get_log_files();
+		$handle  = sanitize_title( $handle );
 
-		if ( $file ) {
-			if ( is_file( $file ) && is_writable( $file ) ) {
-				$this->close( $handle ); // Close first to be certain no processes keep it alive after it is unlinked.
-				$removed = unlink( $file );
+		if ( isset( $logs[ $handle ] ) && $logs[ $handle ] ) {
+			$file = realpath( trailingslashit( EVF_LOG_DIR ) . $logs[ $handle ] );
+			if ( 0 === stripos( $file, realpath( trailingslashit( EVF_LOG_DIR ) ) ) && is_file( $file ) && is_writable( $file ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
+				$this->close( $file ); // Close first to be certain no processes keep it alive after it is unlinked.
+				$removed = unlink( $file ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
 			}
 			do_action( 'everest_forms_log_remove', $handle, $removed );
 		}
-
 		return $removed;
 	}
 
@@ -260,7 +260,7 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	 *
 	 * Compares the size of the log file to determine whether it is over the size limit.
 	 *
-	 * @param string $handle Log handle
+	 * @param string $handle Log handle.
 	 * @return bool True if if should be rotated.
 	 */
 	protected function should_rotate( $handle ) {
@@ -291,7 +291,7 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	 *     base.0.log -> base.1.log
 	 *     base.log   -> base.0.log
 	 *
-	 * @param string $handle Log handle
+	 * @param string $handle Log handle.
 	 */
 	protected function log_rotate( $handle ) {
 		for ( $i = 8; $i >= 0; $i-- ) {
@@ -303,28 +303,28 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Increment a log file suffix.
 	 *
-	 * @param string $handle Log handle
+	 * @param string   $handle Log handle.
 	 * @param null|int $number Optional. Default null. Log suffix number to be incremented.
 	 * @return bool True if increment was successful, otherwise false.
 	 */
 	protected function increment_log_infix( $handle, $number = null ) {
 		if ( null === $number ) {
-			$suffix = '';
+			$suffix      = '';
 			$next_suffix = '.0';
 		} else {
-			$suffix = '.' . $number;
-			$next_suffix = '.' . ($number + 1);
+			$suffix      = '.' . $number;
+			$next_suffix = '.' . ( $number + 1 );
 		}
 
 		$rename_from = self::get_log_file_path( "{$handle}{$suffix}" );
-		$rename_to = self::get_log_file_path( "{$handle}{$next_suffix}" );
+		$rename_to   = self::get_log_file_path( "{$handle}{$next_suffix}" );
 
 		if ( $this->is_open( $rename_from ) ) {
 			$this->close( $rename_from );
 		}
 
-		if ( is_writable( $rename_from ) ) {
-			return rename( $rename_from, $rename_to );
+		if ( is_writable( $rename_from ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
+			return rename( $rename_from, $rename_to ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_rename
 		} else {
 			return false;
 		}
@@ -348,13 +348,17 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Get a log file name.
 	 *
+	 * File names consist of the handle, followed by the date, followed by a hash, .log.
+	 *
 	 * @since 3.3
 	 * @param string $handle Log name.
 	 * @return bool|string The log file name or false if cannot be determined.
 	 */
 	public static function get_log_file_name( $handle ) {
 		if ( function_exists( 'wp_hash' ) ) {
-			return sanitize_file_name( $handle . '-' . wp_hash( $handle ) . '.log' );
+			$date_suffix = date( 'Y-m-d', time() ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+			$hash_suffix = wp_hash( $handle );
+			return sanitize_file_name( implode( '-', array( $handle, $date_suffix, $hash_suffix ) ) . '.log' );
 		} else {
 			evf_doing_it_wrong( __METHOD__, __( 'This method should not be called before plugins_loaded.', 'everest-forms' ), '1.2' );
 			return false;
@@ -364,12 +368,12 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 	/**
 	 * Cache log to write later.
 	 *
-	 * @param string $entry Log entry text
-	 * @param string $handle Log entry handle
+	 * @param string $entry Log entry text.
+	 * @param string $handle Log entry handle.
 	 */
 	protected function cache_log( $entry, $handle ) {
 		$this->cached_logs[] = array(
-			'entry' => $entry,
+			'entry'  => $entry,
 			'handle' => $handle,
 		);
 	}
@@ -381,5 +385,50 @@ class EVF_Log_Handler_File extends EVF_Log_Handler {
 		foreach ( $this->cached_logs as $log ) {
 			$this->add( $log['entry'], $log['handle'] );
 		}
+	}
+
+	/**
+	 * Delete all logs older than a defined timestamp.
+	 *
+	 * @since 1.6.2
+	 * @param integer $timestamp Timestamp to delete logs before.
+	 */
+	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		$log_files = self::get_log_files();
+
+		foreach ( $log_files as $log_file ) {
+			$last_modified = filemtime( trailingslashit( EVF_LOG_DIR ) . $log_file );
+
+			if ( $last_modified < $timestamp ) {
+				@unlink( trailingslashit( EVF_LOG_DIR ) . $log_file ); // @codingStandardsIgnoreLine.
+			}
+		}
+	}
+
+	/**
+	 * Get all log files in the log directory.
+	 *
+	 * @since 1.6.2
+	 * @return array
+	 */
+	public static function get_log_files() {
+		$files  = @scandir( EVF_LOG_DIR ); // @codingStandardsIgnoreLine.
+		$result = array();
+
+		if ( ! empty( $files ) ) {
+			foreach ( $files as $key => $value ) {
+				if ( ! in_array( $value, array( '.', '..' ), true ) ) {
+					if ( ! is_dir( $value ) && strstr( $value, '.log' ) ) {
+						$result[ sanitize_title( $value ) ] = $value;
+					}
+				}
+			}
+		}
+
+		return $result;
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,6 +12,7 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 global $wpdb;
 
+wp_clear_scheduled_hook( 'everest_forms_cleanup_logs' );
 wp_clear_scheduled_hook( 'everest_forms_cleanup_sessions' );
 
 /*
@@ -20,7 +21,7 @@ wp_clear_scheduled_hook( 'everest_forms_cleanup_sessions' );
  * and to ensure only the site owner can perform this action.
  */
 if ( defined( 'EVF_REMOVE_ALL_DATA' ) && true === EVF_REMOVE_ALL_DATA ) {
-	include_once( dirname( __FILE__ ) . '/includes/class-evf-install.php' );
+	include_once dirname( __FILE__ ) . '/includes/class-evf-install.php';
 
 	// Roles + caps.
 	EVF_Install::remove_roles();


### PR DESCRIPTION
This PR implements a new cron job to clean up log files after (default) 30 days.

To work this,

- Adds a new daily cron job for log cleanup.
- Rotates the log file daily by appending the date to the file name.
- Cleanup calls the current logger to delete logs before a timestamp
- File based logger loops over log files and deletes based on last modified time.

Resolves phpcs issues with edited files.