### PR TITLE
Tweak - Use apply_shortocodes() as an alias for do_shortcode()

### DIFF
--- a/includes/class-everest-forms.php
+++ b/includes/class-everest-forms.php
@@ -21,7 +21,7 @@ final class EverestForms {
 	 *
 	 * @var string
 	 */
-	public $version = '1.6.4';
+	public $version = '1.6.5';
 
 	/**
 	 * The single instance of the class.

--- a/includes/class-evf-template-loader.php
+++ b/includes/class-evf-template-loader.php
@@ -213,7 +213,7 @@ class EVF_Template_Loader {
 		remove_filter( 'the_content', array( __CLASS__, 'form_preview_content_filter' ) );
 
 		if ( current_user_can( 'manage_everest_forms' ) ) {
-			$content = do_shortcode( '[everest_form id="' . absint( self::$form_id ) . '"]' );
+			$content = apply_shortcodes( '[everest_form id="' . absint( self::$form_id ) . '"]' );
 		}
 
 		self::$in_content_filter = false;

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1989,3 +1989,25 @@ function evf_cleanup_logs() {
 	}
 }
 add_action( 'everest_forms_cleanup_logs', 'evf_cleanup_logs' );
+
+
+if ( ! function_exists( 'apply_shortcodes' ) ) {
+
+	/**
+	 * Search content for shortcodes and filter shortcodes through their hooks.
+	 *
+	 * This function is an alias for do_shortcode().
+	 *
+	 * @since 1.6.6
+	 *
+	 * @see do_shortcode()
+	 *
+	 * @param string $content     Content to search for shortcodes.
+	 * @param bool   $ignore_html When true, shortcodes inside HTML elements will be skipped.
+	 *                            Default false.
+	 * @return string Content with shortcodes filtered out.
+	 */
+	function apply_shortcodes( $content, $ignore_html = false ) {
+		return do_shortcode( $content, $ignore_html );
+	}
+}

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1998,7 +1998,7 @@ if ( ! function_exists( 'apply_shortcodes' ) ) {
 	 *
 	 * This function is an alias for do_shortcode().
 	 *
-	 * @since 1.6.6
+	 * @since 1.6.5
 	 *
 	 * @see do_shortcode()
 	 *


### PR DESCRIPTION
Which is meant to get better semantics and for WordPress 5.4 Compatibility?

Ref: https://make.wordpress.org/core/2020/02/13/wordpress-5-4-introduces-apply-shortcodes-as-an-alias-for-do-shortcode/

### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Changelog entry

> Tweak - Use apply_shortocodes() as an alias for do_shortcode() for better semantics.
