### PR TITLE
Fix - WPML compatibility now supported for choice fields

### DIFF
--- a/includes/fields/class-evf-field-checkbox.php
+++ b/includes/fields/class-evf-field-checkbox.php
@@ -355,6 +355,11 @@ class EVF_Field_Checkbox extends EVF_Form_Fields {
 				continue;
 			}
 
+			// WPML Compatibility.
+			if ( isset( $choice['label']['text'], $choice['label']['attr']['for'] ) && '' !== $choice['label']['text'] ) {
+				$choice['label']['text'] = evf_string_translation( $form_data['id'], $field['id'], $choice['label']['text'] );
+			}
+
 			// Conditional logic.
 			if ( isset( $choices['primary'] ) ) {
 				$choice['attr']['conditional_id'] = $choices['primary']['attr']['conditional_id'];

--- a/includes/fields/class-evf-field-radio.php
+++ b/includes/fields/class-evf-field-radio.php
@@ -286,6 +286,11 @@ class EVF_Field_Radio extends EVF_Form_Fields {
 				continue;
 			}
 
+			// WPML Compatibility.
+			if ( isset( $choice['label']['text'], $choice['label']['attr']['for'] ) && '' !== $choice['label']['text'] ) {
+				$choice['label']['text'] = evf_string_translation( $form_data['id'], $field['id'], $choice['label']['text'] );
+			}
+
 			// Conditional logic.
 			if ( isset( $choices['primary'] ) ) {
 				$choice['attr']['conditional_id'] = $choices['primary']['attr']['conditional_id'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR intends to address choice fields being unable to allow string translations via WPML.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes Ticket: https://wordpress.org/support/topic/wpml-checkbox-translation-everest-form/

### How to test the changes in this Pull Request:

1. Boot up WPML.
2. Preview the form at least once after creation.
3. Now, the checkbox and radio choice fields will have their string translations appear correctly in WPML.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WPML compatibility now supported for choice fields
