### PR TITLE
Enhance - Added option to disable certain dates in the Date/Time field

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -244,11 +244,11 @@
 
 			// Reformat the selected dates input value for `Disable dates` option when the date format changes.
 			$( document.body ).on( 'change', '.evf-date-format', function( e ) {
-				var $disable_dates = $( '.everest-forms-field-option:visible .everest-forms-disable-dates' );
-				var flatpicker = $disable_dates.get(0)._flatpickr;
-				var selectedDates = flatpicker.selectedDates;
-				var date_format = $( this ).val();
-				var formatedDates = [];
+				var $disable_dates = $( '.everest-forms-field-option:visible .everest-forms-disable-dates' ),
+					flatpicker = $disable_dates.get(0)._flatpickr,
+					selectedDates = flatpicker.selectedDates,
+					date_format = $( this ).val(),
+					formatedDates = [];
 
 				selectedDates.forEach( function( date ) {
 					formatedDates.push( flatpickr.formatDate( date, date_format ) );
@@ -258,7 +258,7 @@
 			});
 
 			// Clear disabled dates.
-			$( document.body ).on( 'click', '.evf-clear-disabled-dates', function( e ) {
+			$( document.body ).on( 'click', '.evf-clear-disabled-dates', function() {
 				$( '.everest-forms-field-option:visible .everest-forms-disable-dates' ).get(0)._flatpickr.clear();
 			});
 		},
@@ -1637,7 +1637,7 @@
 					EVFPanelBuilder.paymentFieldAppendToQuantity( dragged_el_id );
 					EVFPanelBuilder.paymentFieldAppendToDropdown( dragged_field_id, field_type );
 
-					// Initializations.
+					// Initialization Datepickers.
 					EVFPanelBuilder.init_datepickers();
 		 		}
 		 	});

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -213,6 +213,7 @@
 			EVFPanelBuilder.bindToggleHandleActions();
 			EVFPanelBuilder.bindLabelEditInputActions();
 			EVFPanelBuilder.bindSyncedInputActions();
+			EVFPanelBuilder.init_datepickers();
 
 			// Fields Panel.
 			EVFPanelBuilder.bindUIActionsFields();
@@ -220,6 +221,46 @@
 			if ( evf_data.tab === 'field-options' ) {
 				$( '.evf-panel-field-options-button' ).trigger( 'click' );
 			}
+		},
+
+		/**
+		 * Initialize date pickers like min/max date, disable dates etc.
+		 *
+		 * @since 1.7.0
+		 */
+		init_datepickers: function() {
+			var date_format = $( '.everest-forms-disable-dates' ).data( 'date-format' );
+			var selection_mode = 'multiple';
+
+			// Initialize `Disable dates` option's date pickers that hasn't been initialized.
+			$( '.everest-forms-disable-dates' ).each( function() {
+				if ( ! $( this ).get(0)._flatpickr ) {
+					$( this ).flatpickr({
+						dateFormat: date_format,
+						mode: selection_mode,
+					});
+				}
+			})
+
+			// Reformat the selected dates input value for `Disable dates` option when the date format changes.
+			$( document.body ).on( 'change', '.evf-date-format', function( e ) {
+				var $disable_dates = $( '.everest-forms-field-option:visible .everest-forms-disable-dates' );
+				var flatpicker = $disable_dates.get(0)._flatpickr;
+				var selectedDates = flatpicker.selectedDates;
+				var date_format = $( this ).val();
+				var formatedDates = [];
+
+				selectedDates.forEach( function( date ) {
+					formatedDates.push( flatpickr.formatDate( date, date_format ) );
+				})
+				flatpicker.set( 'dateFormat', date_format );
+				$disable_dates.val( formatedDates.join( ', ' ) );
+			});
+
+			// Clear disabled dates.
+			$( document.body ).on( 'click', '.evf-clear-disabled-dates', function( e ) {
+				$( '.everest-forms-field-option:visible .everest-forms-disable-dates' ).get(0)._flatpickr.clear();
+			});
 		},
 
 		/**
@@ -1595,6 +1636,9 @@
 					EVFPanelBuilder.conditionalLogicAppendFieldIntegration( dragged_el_id );
 					EVFPanelBuilder.paymentFieldAppendToQuantity( dragged_el_id );
 					EVFPanelBuilder.paymentFieldAppendToDropdown( dragged_field_id, field_type );
+
+					// Initializations.
+					EVFPanelBuilder.init_datepickers();
 		 		}
 		 	});
 		},

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -226,13 +226,13 @@
 		/**
 		 * Initialize date pickers like min/max date, disable dates etc.
 		 *
-		 * @since 1.7.0
+		 * @since 1.6.6
 		 */
 		init_datepickers: function() {
 			var date_format = $( '.everest-forms-disable-dates' ).data( 'date-format' );
 			var selection_mode = 'multiple';
 
-			// Initialize `Disable dates` option's date pickers that hasn't been initialized.
+			// Initialize "Disable dates" option's date pickers that hasn't been initialized.
 			$( '.everest-forms-disable-dates' ).each( function() {
 				if ( ! $( this ).get(0)._flatpickr ) {
 					$( this ).flatpickr({

--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -125,7 +125,7 @@ jQuery( function ( $ ) {
 								minuteIncrement : timeInterval,
 								dateFormat      : inputData.dateFormat,
 								time_24hr		: inputData.dateFormat.includes( 'H:i' ),
-								disable       : disableDates,
+								disable         : disableDates,
 							});
 						break;
 						default:

--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -74,7 +74,13 @@ jQuery( function ( $ ) {
 			if ( evfDateField.length > 0 ) {
 				$( '.flatpickr-field' ).each( function() {
 					var timeInterval = 5,
-						inputData  	 = $( this ).data();
+						inputData  	 = $( this ).data(),
+						disableDates = [];
+
+					// Extract list of disabled dates.
+					if ( inputData.disableDates ) {
+						disableDates = inputData.disableDates.split( ',' );
+					}
 
 					switch( inputData.dateTime ) {
 						case 'date':
@@ -84,7 +90,8 @@ jQuery( function ( $ ) {
 								mode          : inputData.mode,
 								minDate       : inputData.minDate,
 								maxDate       : inputData.maxDate,
-								dateFormat    : inputData.dateFormat
+								dateFormat    : inputData.dateFormat,
+								disable       : disableDates,
 							});
 						break;
 						case 'time':
@@ -117,7 +124,8 @@ jQuery( function ( $ ) {
 								maxDate         : inputData.maxDate,
 								minuteIncrement : timeInterval,
 								dateFormat      : inputData.dateFormat,
-								time_24hr		: inputData.dateFormat.includes( 'H:i' )
+								time_24hr		: inputData.dateFormat.includes( 'H:i' ),
+								disable       : disableDates,
 							});
 						break;
 						default:

--- a/includes/admin/class-evf-admin-assets.php
+++ b/includes/admin/class-evf-admin-assets.php
@@ -38,6 +38,7 @@ class EVF_Admin_Assets {
 		wp_register_style( 'jquery-ui-style', evf()->plugin_url() . '/assets/css/jquery-ui/jquery-ui.min.css', array(), EVF_VERSION );
 		wp_register_style( 'jquery-confirm', evf()->plugin_url() . '/assets/css/jquery-confirm/jquery-confirm.min.css', array(), '3.3.0' );
 		wp_register_style( 'perfect-scrollbar', evf()->plugin_url() . '/assets/css/perfect-scrollbar/perfect-scrollbar.css', array(), '1.4.0' );
+		wp_register_style( 'flatpickr', evf()->plugin_url() . '/assets/css/flatpickr.css', array(), EVF_VERSION );
 
 		// Add RTL support for admin styles.
 		wp_style_add_data( 'everest-forms-admin', 'rtl', 'replace' );
@@ -52,6 +53,7 @@ class EVF_Admin_Assets {
 			wp_enqueue_style( 'jquery-confirm' );
 			wp_enqueue_style( 'jquery-ui-style' );
 			wp_enqueue_style( 'wp-color-picker' );
+			wp_enqueue_style( 'flatpickr' );
 
 			if ( 'everest-forms_page_evf-tools' !== $screen_id ) {
 				wp_enqueue_style( 'perfect-scrollbar' );
@@ -83,6 +85,7 @@ class EVF_Admin_Assets {
 		wp_register_script( 'selectWoo', evf()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.4', true );
 		wp_register_script( 'evf-enhanced-select', evf()->plugin_url() . '/assets/js/admin/evf-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), EVF_VERSION, true );
 		wp_register_script( 'evf-template-controller', evf()->plugin_url() . '/assets/js/admin/form-template-controller' . $suffix . '.js', array( 'jquery' ), EVF_VERSION, true );
+		wp_register_script( 'flatpickr', evf()->plugin_url() . '/assets/js/flatpickr/flatpickr' . $suffix . '.js', array( 'jquery' ), '4.5.1', true );
 		wp_localize_script(
 			'evf-template-controller',
 			'evf_templates',
@@ -110,7 +113,7 @@ class EVF_Admin_Assets {
 				'i18n_searching'            => _x( 'Searching&hellip;', 'enhanced select', 'everest-forms' ),
 			)
 		);
-		wp_register_script( 'evf-form-builder', evf()->plugin_url() . '/assets/js/admin/form-builder' . $suffix . '.js', array( 'jquery', 'jquery-blockui', 'tooltipster', 'jquery-ui-sortable', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-ui-tabs', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-datepicker', 'jquery-confirm', 'evf-clipboard' ), EVF_VERSION, true );
+		wp_register_script( 'evf-form-builder', evf()->plugin_url() . '/assets/js/admin/form-builder' . $suffix . '.js', array( 'jquery', 'jquery-blockui', 'tooltipster', 'jquery-ui-sortable', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-ui-tabs', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-datepicker', 'jquery-confirm', 'evf-clipboard', 'flatpickr' ), EVF_VERSION, true );
 		wp_localize_script(
 			'evf-form-builder',
 			'evf_data',

--- a/includes/fields/class-evf-field-date-time.php
+++ b/includes/fields/class-evf-field-date-time.php
@@ -137,11 +137,39 @@ class EVF_Field_Date_Time extends EVF_Form_Fields {
 				array(
 					'slug'    => 'date_format',
 					'value'   => isset( $field['date_format'] ) ? $field['date_format'] : 'Y-m-d',
+					'class'   => 'evf-date-format',
 					'options' => array(
 						'Y-m-d'  => date( 'Y-m-d' ) . ' (Y-m-d)', // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 						'F j, Y' => date( 'F j, Y' ) . ' (F j, Y)', // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 						'm/d/Y'  => date( 'm/d/Y' ) . ' (m/d/Y)', // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 						'd/m/Y'  => date( 'd/m/Y' ) . ' (d/m/Y)', // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+					),
+				),
+				false
+			);
+
+			// `Disable certain dates` option.
+			$clear_disabled_dates_button = sprintf( '<a href="#" class="evf-clear-disabled-dates">%s</a>', esc_html__( 'Clear', 'everest-forms' ) );
+			$disable_dates_label         = $this->field_element(
+				'label',
+				$field,
+				array(
+					'slug'          => 'disable_dates',
+					'value'         => esc_html__( 'Disable Dates', 'everest-forms' ),
+					'tooltip'       => esc_html__( 'Select which dates you want to disable.', 'everest-forms' ),
+					'after_tooltip' => $clear_disabled_dates_button,
+				),
+				false
+			);
+			$disable_dates               = $this->field_element(
+				'text',
+				$field,
+				array(
+					'slug'  => 'disable_dates',
+					'value' => isset( $field['disable_dates'] ) ? $field['disable_dates'] : '',
+					'class' => 'everest-forms-disable-dates',
+					'data'  => array(
+						'date-format' => isset( $field['date_format'] ) ? $field['date_format'] : 'Y-m-d',
 					),
 				),
 				false
@@ -316,7 +344,7 @@ class EVF_Field_Date_Time extends EVF_Form_Fields {
 
 			$args = array(
 				'slug'    => 'date_format',
-				'content' => $date_format_label . $date_format_select . $date_localization_label . $date_localization_select . '<div class="everest-forms-checklist everest-forms-checklist-inline">' . $current_date_mode . '</div><div class="everest-forms-current-date-format">' . $current_date_default . '</div><div class="everest-forms-min-max-date-format">' . $enable_min_max . '</div><div class="everest-forms-min-max-date-option ' . $class_name . '">' . $min_date_label . $min_date . $max_date_label . $max_date . '</div>',
+				'content' => $date_format_label . $date_format_select . $disable_dates_label . $disable_dates . $date_localization_label . $date_localization_select . '<div class="everest-forms-checklist everest-forms-checklist-inline">' . $current_date_mode . '</div><div class="everest-forms-current-date-format">' . $current_date_default . '</div><div class="everest-forms-min-max-date-format">' . $enable_min_max . '</div><div class="everest-forms-min-max-date-option ' . $class_name . '">' . $min_date_label . $min_date . $max_date_label . $max_date . '</div>',
 			);
 			$this->field_element( 'row', $field, $args );
 
@@ -389,6 +417,11 @@ class EVF_Field_Date_Time extends EVF_Form_Fields {
 		// Input primary: data-time-interval.
 		if ( ! empty( $field['time_interval'] ) ) {
 			$properties['inputs']['primary']['attr']['data-time-interval'] = esc_attr( $field['time_interval'] );
+		}
+
+		// Input primary: Disabled dates data.
+		if ( ! empty( $field['disable_dates'] ) ) {
+			$properties['inputs']['primary']['attr']['data-disable-dates'] = esc_attr( $field['disable_dates'] );
 		}
 
 		// Input primary: data-date-time.

--- a/includes/fields/class-evf-field-date-time.php
+++ b/includes/fields/class-evf-field-date-time.php
@@ -148,8 +148,8 @@ class EVF_Field_Date_Time extends EVF_Form_Fields {
 				false
 			);
 
-			// `Disable certain dates` option.
-			$clear_disabled_dates_button = sprintf( '<a href="#" class="evf-clear-disabled-dates">%s</a>', esc_html__( 'Clear', 'everest-forms' ) );
+			// Disable certain dates option.
+			$clear_disabled_dates_button = sprintf( '<a href="#" class="evf-clear-disabled-dates after-label-description">%s</a>', esc_html__( 'Clear', 'everest-forms' ) );
 			$disable_dates_label         = $this->field_element(
 				'label',
 				$field,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds an option to disable certain dates for the `Date / Time` field.

### How to test the changes in this Pull Request:

1. Create a form and add some `Date / Time` fields
2. Go to `Field Options` > `Advanced Settings` > `Disable dates`
3. Select a few dates which you want to disable
4. Go to the frontend and you should see the selected dates should be disabled

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Added option to disable certain dates in the `Date / Time` field
