### PR TITLE
Tweak - Custom Captcha field now shown as part of pro fields.

### DIFF
--- a/includes/class-evf-forms-features.php
+++ b/includes/class-evf-forms-features.php
@@ -38,6 +38,7 @@ class EVF_Forms_Features {
 			'EVF_Field_Signature',
 			'EVF_Field_Address',
 			'EVF_Field_Country',
+			'EVF_Field_Captcha',
 			'EVF_Field_Payment_Single',
 			'EVF_Field_Payment_Radio',
 			'EVF_Field_Payment_Checkbox',

--- a/includes/fields/class-evf-field-captcha.php
+++ b/includes/fields/class-evf-field-captcha.php
@@ -20,7 +20,7 @@ class EVF_Field_Captcha extends EVF_Form_Fields {
 		$this->name   = esc_html__( 'Captcha', 'everest-forms' );
 		$this->type   = 'captcha';
 		$this->icon   = 'evf-icon evf-icon-captcha';
-		$this->order  = 130;
+		$this->order  = 160;
 		$this->group  = 'advanced';
 		$this->is_pro = true;
 

--- a/includes/fields/class-evf-field-captcha.php
+++ b/includes/fields/class-evf-field-captcha.php
@@ -20,7 +20,7 @@ class EVF_Field_Captcha extends EVF_Form_Fields {
 		$this->name   = esc_html__( 'Captcha', 'everest-forms' );
 		$this->type   = 'captcha';
 		$this->icon   = 'evf-icon evf-icon-captcha';
-		$this->order  = 50;
+		$this->order  = 130;
 		$this->group  = 'advanced';
 		$this->is_pro = true;
 

--- a/includes/fields/class-evf-field-captcha.php
+++ b/includes/fields/class-evf-field-captcha.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Captcha field
+ *
+ * @package EverestForms\Fields
+ * @since   1.6.5
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * EVF_Field_Captcha Class.
+ */
+class EVF_Field_Captcha extends EVF_Form_Fields {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->name   = esc_html__( 'Captcha', 'everest-forms' );
+		$this->type   = 'captcha';
+		$this->icon   = 'evf-icon evf-icon-captcha';
+		$this->order  = 50;
+		$this->group  = 'advanced';
+		$this->is_pro = true;
+
+		parent::__construct();
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

![image](https://user-images.githubusercontent.com/30156167/78960982-7bcd4f00-7b0f-11ea-8066-46e410514c77.png)

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ref: https://github.com/wpeverest/everest-forms-pro/issues/158

### How to test the changes in this Pull Request:

1. Disable Captcha addon.
2. Observe that Captcha addon is now shown as premium field.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Custom Captcha field now shown as part of pro fields.
