### PR TITLE
Update GH Actions workflow to support assets/readme update

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - master
+jobs:
+  master:
+    name: Push to master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@master
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -14,4 +14,3 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SLUG: everest-forms


### PR DESCRIPTION
As advertised and since `SLUG` - defaults to the repository name, I have remove this optional environmental variable in both actions workflow.

This action commits any readme and WordPress.org-specific assets changes in `master` branch to the WordPress.org plugin repository if no other changes have been made since the last deployment to WordPress.org. For ref: https://github.com/10up/action-wordpress-plugin-asset-update