### PR TITLE
Enhance - Show total unread entries count in the main menu

### DIFF
--- a/includes/admin/class-evf-admin-menus.php
+++ b/includes/admin/class-evf-admin-menus.php
@@ -138,14 +138,17 @@ class EVF_Admin_Menus {
 
 		// Count unread entries from all forms.
 		foreach ( $forms as $form_id => $form_title ) {
-			$entries               = evf_search_entries(
+			$entries = evf_search_entries(
 				array(
 					'form_id' => $form_id,
 					'status'  => 'unread',
 					'limit'   => -1,
 				)
 			);
-			$unread_entries_count += count( $entries );
+
+			if ( is_array( $entries ) ) {
+				$unread_entries_count += count( $entries );
+			}
 		}
 
 		if ( $unread_entries_count > 0 ) {

--- a/includes/admin/class-evf-admin-menus.php
+++ b/includes/admin/class-evf-admin-menus.php
@@ -131,8 +131,27 @@ class EVF_Admin_Menus {
 	 * Add menu item.
 	 */
 	public function entries_menu() {
-		$entries_page = add_submenu_page( 'everest-forms', esc_html__( 'Everest Forms Entries', 'everest-forms' ), esc_html__( 'Entries', 'everest-forms' ), 'manage_everest_forms', 'evf-entries', array( $this, 'entries_page' ) );
+		$menu_title                 = esc_html__( 'Entries', 'everest-forms' );
+		$unread_entries_count       = 0;
+		$unread_entries_count_label = '';
+		$forms                      = evf_get_all_forms();
 
+		// Count unread entries from all forms.
+		foreach ( $forms as $form_id => $form_title ) {
+			$entries               = evf_search_entries(
+				array(
+					'form_id' => $form_id,
+					'status'  => 'unread',
+					'limit'   => -1,
+				)
+			);
+			$unread_entries_count += count( $entries );
+		}
+
+		if ( $unread_entries_count > 0 ) {
+			$unread_entries_count_label = sprintf( ' <span class="update-plugins"><span class="plugin-count">%s</span></span>', $unread_entries_count );
+		}
+		$entries_page = add_submenu_page( 'everest-forms', esc_html__( 'Everest Forms Entries', 'everest-forms' ), $menu_title . $unread_entries_count_label, 'manage_everest_forms', 'evf-entries', array( $this, 'entries_page' ) );
 		add_action( 'load-' . $entries_page, array( $this, 'entries_page_init' ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a feature to show total number of unread entries in the main menu.

![image](https://user-images.githubusercontent.com/58679177/79679580-a5c8f480-8226-11ea-9675-7f17f023ad88.png)


### How to test the changes in this Pull Request:

1. Create a form and submit a few entries
2. Now go to entries page or any other Everest Forms page
3. You should see that there's a label as in the above screenshot which contains a number representing the number of unread entries
4. Also try to view some unread entries and see if the number decreases

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Show total unread entries count in the main menu
