### PR TITLE
Fix - False positive required message upon email validation

### DIFF
--- a/includes/fields/class-evf-field-email.php
+++ b/includes/fields/class-evf-field-email.php
@@ -349,7 +349,8 @@ class EVF_Field_Email extends EVF_Form_Fields {
 				update_option( 'evf_validation_error', 'yes' );
 			}
 
-			if ( isset( $field_submit ) && ! is_email( $field_submit ) ) {
+			// Only check for email validity in case of not empty.
+			if ( ! empty( $field_submit ) && ! is_email( $field_submit ) ) {
 				evf()->task->errors[ $form_id ][ $field_id ] = $invalid_email;
 				update_option( 'evf_validation_error', 'yes' );
 				return;
@@ -377,7 +378,8 @@ class EVF_Field_Email extends EVF_Form_Fields {
 				}
 			}
 
-			if ( isset( $field_submit['primary'] ) && ! is_email( $field_submit['primary'] ) ) {
+			// Only check for email validity in case of not empty.
+			if ( ! empty( $field_submit['primary'] ) && ! is_email( $field_submit['primary'] ) ) {
 				evf()->task->errors[ $form_id ][ $field_id ]['primary'] = $invalid_email;
 				update_option( 'evf_validation_error', 'yes' );
 				return;

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -609,7 +609,7 @@ class EVF_Shortcode_Form {
 			}
 		}
 		$errors     = isset( evf()->task->errors[ $form_id ][ $field_id ] ) ? evf()->task->errors[ $form_id ][ $field_id ] : '';
-		$defaults   = ( ! is_array( $_POST['everest_forms']['form_fields'][ $field_id ] ) && ! empty( $_POST['everest_forms']['form_fields'][ $field_id ] ) ) ? $_POST['everest_forms']['form_fields'][ $field_id ] : '';
+		$defaults   = isset( $_POST['everest_forms']['form_fields'][ $field_id ] ) && ( ! is_array( $_POST['everest_forms']['form_fields'][ $field_id ] ) && ! empty( $_POST['everest_forms']['form_fields'][ $field_id ] ) ) ? $_POST['everest_forms']['form_fields'][ $field_id ] : ''; // @codingStandardsIgnoreLine
 		$properties = apply_filters(
 			'everest_forms_field_properties_' . $field['type'],
 			array(

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -609,6 +609,7 @@ class EVF_Shortcode_Form {
 			}
 		}
 		$errors     = isset( evf()->task->errors[ $form_id ][ $field_id ] ) ? evf()->task->errors[ $form_id ][ $field_id ] : '';
+		$defaults   = ( ! is_array( $_POST['everest_forms']['form_fields'][ $field_id ] ) && ! empty( $_POST['everest_forms']['form_fields'][ $field_id ] ) ) ? $_POST['everest_forms']['form_fields'][ $field_id ] : '';
 		$properties = apply_filters(
 			'everest_forms_field_properties_' . $field['type'],
 			array(
@@ -636,7 +637,7 @@ class EVF_Shortcode_Form {
 					'primary' => array(
 						'attr'     => array(
 							'name'        => "everest_forms[form_fields][{$field_id}]",
-							'value'       => ( isset( $field['default_value'] ) && ! empty( $field['default_value'] ) ) ? apply_filters( 'everest_forms_process_smart_tags', $field['default_value'], $form_data ) : ( isset( $_POST['everest_forms']['form_fields'][ $field_id ] ) ? $_POST['everest_forms']['form_fields'][ $field_id ] : '' ), // @codingStandardsIgnoreLine
+							'value'       => ! empty( $field['default_value'] ) ? apply_filters( 'everest_forms_process_smart_tags', $field['default_value'], $form_data ) : $defaults,
 							'placeholder' => ! empty( $field['placeholder'] ) ? evf_string_translation( $form_data['id'], $field['id'], $field['placeholder'], '-placeholder' ) : '',
 						),
 						'class'    => $attributes['input_class'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR intends to address the unfortunate bug that got introduced due to the PR: https://github.com/wpeverest/everest-forms/pull/376. Multiple email fields in a form were getting incorrectly flagged without checking if they're actually required or not. This PR seeks to modify behavior, by only checking the email syntax in case of if a non empty field value is submitted.

I'd like to issue my sincerest apologies for this major oversight. I'll be sure keep an eye out, so I do not repeat something similar in the coming days.

### How to test the changes in this Pull Request:

1. Add in multiple emails, and make sure only one of them is set to required.
2. Preview form, only fill the required email field, and leave the rest.
3. Observe no errors upon attempted submission of the form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - False-positive required message upon email validation.
