### PR TITLE
Fix - shortcode rendering for plain copy-paste shortcodes

### DIFF
--- a/includes/class-evf-shortcodes.php
+++ b/includes/class-evf-shortcodes.php
@@ -20,7 +20,7 @@ class EVF_Shortcodes {
 		self::init_shortcode_hooks();
 
 		$shortcodes = array(
-			'everest_form' => __CLASS__ . '::form',
+			'everest_forms' => __CLASS__ . '::form',
 		);
 
 		foreach ( $shortcodes as $shortcode => $function ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR seeks to address shortcodes not being rendered right in case of the shortcode copy paste in within everest forms. The shortcode was registered as "everest_form", whereas it should both semantically and gramatically be "everest_forms".

### How to test the changes in this Pull Request:

1. Copy paste the shortcode from the all forms dashboard to any classic editor as-is.
2. Upon preview/publish, notice that the shortcode is rendered correctly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - shortcode rendering for plain copy-paste shortcodes.


### Before

![image](https://user-images.githubusercontent.com/30156167/80479068-306bcb00-896e-11ea-9023-2b9d22ae26a7.png)

### After 

![image](https://user-images.githubusercontent.com/30156167/80479105-424d6e00-896e-11ea-967c-134719ef8a62.png)

### Reproduction

![image](https://user-images.githubusercontent.com/30156167/80479150-52fde400-896e-11ea-89aa-29d01b9f45bd.png)

