### PR TITLE
Fix - Export of field data with html encoded special characters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 
 = 1.6.8 - xx-xx-2020 =
 * Added - Introduce `get_multiple` method in `EVF_Form_Handler` to fetch multiple forms.
+* Fix - Export of field data with HTML encoded special characters.
 * Fix - The field placeholder & default value 0 (zero) does not display on the frontend.
 * Tweak - Updated jQuery Validation JS library to v1.19.2.
 * Tweak - Add trigger `everest_forms_loaded` to notify plugins that the core was loaded.

--- a/includes/export/abstract-evf-csv-exporter.php
+++ b/includes/export/abstract-evf-csv-exporter.php
@@ -287,7 +287,7 @@ abstract class EVF_CSV_Exporter {
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
 		if ( in_array( mb_substr( $data, 0, 1 ), $active_content_triggers, true ) ) { // @codingStandardsIgnoreLine
-			$data = "'" . $data . "'";
+			$data = "'" . $data;
 		}
 
 		return $data;
@@ -307,7 +307,6 @@ abstract class EVF_CSV_Exporter {
 		}
 
 		$use_mb = function_exists( 'mb_convert_encoding' );
-		$data   = (string) urldecode( $data );
 
 		if ( $use_mb ) {
 			$encoding = mb_detect_encoding( $data, 'UTF-8, ISO-8859-1', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Export field data containing HTML special characters without decoding,

Closes #444.

### How to test the changes in this Pull Request:

1. Enter the symbol like `+` in field and submit the form.
2. See the entries (it will correctly be displayed) and export the entries.
3. Review the exported file and see with this PR `+` chars should not be removed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Export of field data with HTML encoded special characters.
