### PR TITLE
Fix: WP color field initialization when multi-part addon is enabled

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -2,9 +2,7 @@
 ( function( $, params ) {
 
 	// Colorpicker.
-	$( document ).ready(function() {
-		$( '.evf-colorpicker' ).wpColorPicker();
-	});
+	$( '.evf-colorpicker' ).wpColorPicker();
 
 	// Enable Perfect Scrollbar.
 	$( document ).on( 'init_perfect_scrollbar', function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
The wp color picker field is initialized as early as possbile.

Closes #481  .

### How to test the changes in this Pull Request:

1. Check out the `develop` branch.
2. Enable the multi-part addon.
3. Add a form or edit an existing form. (The page should stuck on loading)
4. Check out the `fix/481` branch.
5. Goto to the same previous form.(The page should load normally)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix initialization of WP color picker when multi-part form addon is activated.
