### PR TITLE
Fix - reCAPTCHA working only for logged in user

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 1.7.0.1 - 20-07-2020 =
+* Fix - reCAPTCHA working only for logged in user.
+* Tweak - Modified `everest_forms_logged_in_user_recaptcha_disabled` with `everest_forms_recaptcha_disabled` hook.
+
 = 1.7.0 - 15-07-2020 =
 * Enhancement - Add support for form restriction addon.
 * Added - Support for bulk options to Checkbox, Multiple Choice and Dropdown fields.

--- a/includes/class-evf-deprecated-filter-hooks.php
+++ b/includes/class-evf-deprecated-filter-hooks.php
@@ -31,6 +31,7 @@ class EVF_Deprecated_Filter_Hooks extends EVF_Deprecated_Hooks {
 		'everest_forms_frontend_load'                 => 'evf_frontend_load',
 		'everest_forms_frontend_form_action'          => 'evf_frontend_form_action',
 		'everest_forms_process_smart_tags'            => 'evf_process_smart_tags',
+		'everest_forms_recaptcha_disabled'            => 'everest_forms_logged_in_user_recaptcha_disabled',
 	);
 
 	/**
@@ -39,18 +40,19 @@ class EVF_Deprecated_Filter_Hooks extends EVF_Deprecated_Hooks {
 	 * @var array
 	 */
 	protected $deprecated_version = array(
-		'everest_forms_load_fields'            => '1.2.0',
-		'evf_display_media_button'             => '1.2.0',
-		'everest_forms_show_admin_bar'         => '1.2.0',
-		'everest_forms_builder_fields_buttons' => '1.2.0',
-		'evf_field_data'                       => '1.3.0',
-		'evf_field_properties'                 => '1.3.0',
-		'evf_field_properties_{field_type}'    => '1.3.0',
-		'evf_field_submit'                     => '1.3.2',
-		'evf_field_required_label'             => '1.3.2',
-		'evf_frontend_load'                    => '1.3.2',
-		'evf_frontend_form_action'             => '1.3.2',
-		'evf_process_smart_tags'               => '1.4.2',
+		'everest_forms_load_fields'                       => '1.2.0',
+		'evf_display_media_button'                        => '1.2.0',
+		'everest_forms_show_admin_bar'                    => '1.2.0',
+		'everest_forms_builder_fields_buttons'            => '1.2.0',
+		'evf_field_data'                                  => '1.3.0',
+		'evf_field_properties'                            => '1.3.0',
+		'evf_field_properties_{field_type}'               => '1.3.0',
+		'evf_field_submit'                                => '1.3.2',
+		'evf_field_required_label'                        => '1.3.2',
+		'evf_frontend_load'                               => '1.3.2',
+		'evf_frontend_form_action'                        => '1.3.2',
+		'evf_process_smart_tags'                          => '1.4.2',
+		'everest_forms_logged_in_user_recaptcha_disabled' => '1.7.0.1',
 	);
 
 	/**

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -169,7 +169,7 @@ class EVF_Form_Task {
 			}
 
 			// reCAPTCHA check.
-			if ( is_user_logged_in() && ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
+			if ( ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
 				$recaptcha_type      = get_option( 'everest_forms_recaptcha_type', 'v2' );
 				$invisible_recaptcha = get_option( 'everest_forms_recaptcha_v2_invisible', 'no' );
 

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -169,7 +169,7 @@ class EVF_Form_Task {
 			}
 
 			// reCAPTCHA check.
-			if ( ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
+			if ( ! apply_filters( 'everest_forms_recaptcha_disabled', false ) ) {
 				$recaptcha_type      = get_option( 'everest_forms_recaptcha_type', 'v2' );
 				$invisible_recaptcha = get_option( 'everest_forms_recaptcha_v2_invisible', 'no' );
 

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -43,7 +43,7 @@ class EVF_Shortcode_Form {
 		add_action( 'everest_forms_display_field_after', array( 'EVF_Shortcode_Form', 'description' ), 5, 2 );
 		add_action( 'everest_forms_display_field_after', array( 'EVF_Shortcode_Form', 'wrapper_end' ), 15, 2 );
 		add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'honeypot' ), 15, 3 );
-		if ( ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
+		if ( ! apply_filters( 'everest_forms_recaptcha_disabled', false ) ) {
 			add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'recaptcha' ), 20, 3 );
 		}
 		add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'footer' ), 25, 3 );

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -43,7 +43,7 @@ class EVF_Shortcode_Form {
 		add_action( 'everest_forms_display_field_after', array( 'EVF_Shortcode_Form', 'description' ), 5, 2 );
 		add_action( 'everest_forms_display_field_after', array( 'EVF_Shortcode_Form', 'wrapper_end' ), 15, 2 );
 		add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'honeypot' ), 15, 3 );
-		if ( is_user_logged_in() && ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
+		if ( ! apply_filters( 'everest_forms_logged_in_user_recaptcha_disabled', false ) ) {
 			add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'recaptcha' ), 20, 3 );
 		}
 		add_action( 'everest_forms_frontend_output', array( 'EVF_Shortcode_Form', 'footer' ), 25, 3 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR solves the issue with the reCAPTCHA issue which is working only for logged in users.

Closes https://wordpress.org/support/topic/google-recaptcha-40/

### How to test the changes in this Pull Request:

1. Enable reCAPTCHA with proper keys.
2. Create a page and put the Everest Forms shortcode having the reCAPTCHA option enabled.
3. Logged out from the admin and try to submit the form. The form will be submitted but the reCAPTCHA function will not be called. For that, please put some development code inside the code where the reCAPTCHA function is called.

Add this bit of code in your active theme `functions.php`

```
// Disable reCAPTCHA for logged in user.
add_filter( 'everest_forms_recaptcha_disabled', '__return_true' ); // Use `__return_true` for reverse check!
```

Note: Previously introduced hook `everest_forms_logged_in_user_recaptcha_disabled` is deprecated with `everest_forms_recaptcha_disabled`.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - reCAPTCHA working only for logged in user
