### PR TITLE
Fix - Select field placeholder not displayed and selected

### DIFF
--- a/includes/fields/class-evf-field-select.php
+++ b/includes/fields/class-evf-field-select.php
@@ -92,9 +92,9 @@ class EVF_Field_Select extends EVF_Form_Fields {
 		// Remove primary input.
 		unset( $properties['inputs']['primary'] );
 
-		// Set input container (ul) properties.
+		// Set input container (<select>) properties.
 		$properties['input_container'] = array(
-			'class' => array( ! empty( $field['random'] ) ? 'everest-forms-randomize' : '' ),
+			'class' => array(),
 			'data'  => array(),
 			'id'    => "evf-{$form_id}-field_{$field_id}",
 			'attr'  => array(
@@ -247,6 +247,11 @@ class EVF_Field_Select extends EVF_Form_Fields {
 		$plan = evf_get_license_plan();
 		if ( false !== $plan && ! empty( $field['enhanced_select'] ) && '1' === $field['enhanced_select'] ) {
 			$container['class'][] = 'evf-enhanced-select';
+
+			// Set placeholder for select2.
+			if ( ! empty( $field_placeholder ) ) {
+				$container['data']['placeholder'] = esc_attr( $field_placeholder );
+			}
 		}
 
 		// Check to see if any of the options have selected by default.

--- a/includes/fields/class-evf-field-select.php
+++ b/includes/fields/class-evf-field-select.php
@@ -251,7 +251,7 @@ class EVF_Field_Select extends EVF_Form_Fields {
 
 		// Check to see if any of the options have selected by default.
 		foreach ( $choices as $choice ) {
-			if ( isset( $choice['default'] ) ) {
+			if ( ! empty( $choice['default'] ) ) {
 				$has_default = true;
 				break;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://wordpress.org/support/topic/latest-update-broke-select-placeholders/

### How to test the changes in this Pull Request:

1. Set placeholder for the select field.
2. Test both for enhanced select and normal select.
3. In normal, now placeholder should be selected and in enhanced select placeholder should be displayed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Select field placeholder not displayed in enhanced select and not selected in default select.
