### PR TITLE
Fix - Referral URL Unicode support

### DIFF
--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -652,7 +652,7 @@ class EVF_Form_Task {
 		$user_ip     = evf_get_ip_address();
 		$user_device = evf_get_user_device();
 		$user_agent  = $browser['name'] . '/' . $browser['platform'] . '/' . $user_device;
-		$referer     = ! empty( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+		$referer     = ! empty( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 		$entry_id    = false;
 
 		// GDPR enhancements - If user details are disabled globally discard the IP and UA.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Unicodes were not supported on the Referal link on Entry Section. 

### How to test the changes in this Pull Request:

1. Create a page with Unicode characters on the URL and place Everest Forms on that page.
2. Open that page fill-up the form and submit.
3. Now see the Referral Link on the single entry.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Referral URL unicode support
