### PR TITLE
Fix - Form styles clone on import and duplication

### DIFF
--- a/includes/admin/class-evf-admin-import-export.php
+++ b/includes/admin/class-evf-admin-import-export.php
@@ -57,7 +57,7 @@ class EVF_Admin_Import_Export {
 		// Export form styles if found.
 		$form_styles = get_option( 'everest_forms_styles', array() );
 		if ( ! empty( $form_styles[ $form_id ] ) ) {
-			$export_data['form_styles'] = ( $form_styles[ $form_id ] );
+			$export_data['form_styles'] = wp_json_encode( $form_styles[ $form_id ] );
 		}
 
 		if ( ob_get_contents() ) {
@@ -121,14 +121,17 @@ class EVF_Admin_Import_Export {
 						wp_update_post( $form );
 
 						// Import form styles if present.
+						$style_needed = false;
 						if ( ! empty( $form_data->form_styles ) ) {
+							$style_needed            = true;
 							$form_styles             = get_option( 'everest_forms_styles', array() );
 							$form_styles[ $post_id ] = evf_decode( $form_data->form_styles );
 
-							error_log( print_r( $form_styles, true ) );
-
-							// update_option( 'everest_forms_styles', $form_styles );
+							// Update forms styles.
+							update_option( 'everest_forms_styles', $form_styles );
 						}
+
+						do_action( 'everest_forms_import_form', $post_id, $form, array(), $style_needed );
 
 						// Check for any error while inserting.
 						if ( is_wp_error( $post_id ) ) {

--- a/includes/admin/class-evf-admin-import-export.php
+++ b/includes/admin/class-evf-admin-import-export.php
@@ -54,6 +54,12 @@ class EVF_Admin_Import_Export {
 		$form_name   = strtolower( str_replace( ' ', '-', get_the_title( $form_id ) ) );
 		$file_name   = html_entity_decode( $form_name, ENT_QUOTES, 'UTF-8' ) . '-' . current_time( 'Y-m-d_H:i:s' ) . '.json';
 
+		// Export form styles if found.
+		$form_styles = get_option( 'everest_forms_styles', array() );
+		if ( ! empty( $form_styles[ $form_id ] ) ) {
+			$export_data['form_styles'] = ( $form_styles[ $form_id ] );
+		}
+
 		if ( ob_get_contents() ) {
 			ob_clean();
 		}
@@ -113,6 +119,16 @@ class EVF_Admin_Import_Export {
 						);
 
 						wp_update_post( $form );
+
+						// Import form styles if present.
+						if ( ! empty( $form_data->form_styles ) ) {
+							$form_styles             = get_option( 'everest_forms_styles', array() );
+							$form_styles[ $post_id ] = evf_decode( $form_data->form_styles );
+
+							error_log( print_r( $form_styles, true ) );
+
+							// update_option( 'everest_forms_styles', $form_styles );
+						}
 
 						// Check for any error while inserting.
 						if ( is_wp_error( $post_id ) ) {

--- a/includes/class-evf-form-handler.php
+++ b/includes/class-evf-form-handler.php
@@ -298,6 +298,17 @@ class EVF_Form_Handler {
 		$form    = apply_filters( 'everest_forms_save_form_args', $form, $data, $args );
 		$form_id = wp_update_post( $form );
 
+		// Import form styles if present.
+		$style_needed = false;
+		if ( ! empty( $data['form_styles'] ) ) {
+			$style_needed            = true;
+			$form_styles             = get_option( 'everest_forms_styles', array() );
+			$form_styles[ $form_id ] = evf_decode( $data['form_styles'] );
+
+			// Update forms styles.
+			update_option( 'everest_forms_styles', $form_styles );
+		}
+
 		// Restore removed content filters.
 		if ( $has_kses ) {
 			kses_init_filters();
@@ -306,7 +317,7 @@ class EVF_Form_Handler {
 			wp_init_targeted_link_rel_filters();
 		}
 
-		do_action( 'everest_forms_save_form', $form_id, $form );
+		do_action( 'everest_forms_save_form', $form_id, $form, array(), $style_needed );
 
 		return $form_id;
 	}
@@ -344,6 +355,12 @@ class EVF_Form_Handler {
 
 			// Get the form data.
 			$new_form_data = evf_decode( $form->post_content );
+
+			// Get the form styles.
+			$form_styles = get_option( 'everest_forms_styles', array() );
+			if ( ! empty( $form_styles[ $id ] ) ) {
+				$new_form_data['form_styles'] = wp_json_encode( $form_styles[ $id ] );
+			}
 
 			// Remove form ID from title if present.
 			$new_form_data['settings']['form_title'] = str_replace( '(ID #' . absint( $id ) . ')', '', $new_form_data['settings']['form_title'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://wpeverest.helpmonks.com/mailbox/5dca366ef1d5a91590eed32a/assigned/5fb7bb8c4722b6751869a9f8?from=mine

### How to test the changes in this Pull Request:

1. Checkout this PR with respective style customizer PR-289.
2. Export any one of the forms with customization work done.
3. Try to import and duplicate the form, styles should be a clone for the newly imported/duplicated form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form styles clone on import and duplication
