### PR TITLE
Fix - Undefined form_id on form restriction

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2218,7 +2218,7 @@ jQuery( function ( $ ) {
 	});
 
 	// Toggle form status.
-	$( document ).on( 'change', '.everest-forms_page_evf-builder .everest-forms-toggle-form input', function(e) {
+	$( document ).on( 'change', '.wp-list-table .everest-forms-toggle-form input', function(e) {
 		e.stopPropagation();
 		$.post( evf_data.ajax_url, {
 			action: 'everest_forms_enabled_form',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR solves the issue of  undefined variable form_id not found while toggling the  Max number of Entries.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Undefined form_id on form restriction addon
