### PR TITLE
Fix PayPal standard Redirection Issue

### DIFF
--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -1,24 +1,22 @@
 /* global everest_forms_ajax_submission_params */
 jQuery( function( $ ) {
 	'use strict';
-
 	var evf_ajax_submission_init = function(){
 		var form = $( 'form[data-ajax_submission="1"]' );
-
+		
 		form.each( function( i, v ) {
 			$( document ).ready( function() {
 				var formTuple = $( v ),
 					btn = formTuple.find( '.evf-submit' ),
 					stripeForms = formTuple.find( "[data-gateway*='stripe']" );
-
 				// If it's an ajax form containing a stripe gateway, donot latch into the button.
-				if ( stripeForms.length > 0 ) {
+	
+				if ( stripeForms.length > 0  && 0 === stripeForms.children.length ) {
 					return;
 				}
 
 				btn.on( 'click', function( e ) {
 					var data = formTuple.serializeArray();
-
 					e.preventDefault();
 
 					// We let the bubbling events in form play itself out.
@@ -51,6 +49,7 @@ jQuery( function( $ ) {
 						url: everest_forms_ajax_submission_params.ajax_url,
 						type: 'POST',
 						data: data
+	
 					})
 					.done( function ( xhr, textStatus, errorThrown ) {
 						var redirect_url = ( xhr.data && xhr.data.redirect_url ) ? xhr.data.redirect_url : '';

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -179,6 +179,7 @@ class EVF_Shortcode_Form {
 	 * @param array $form_data Form data.
 	 */
 	public static function label( $field, $form_data ) {
+		
 		$label = $field['properties']['label'];
 
 		// If the label is empty or disabled don't proceed.
@@ -326,6 +327,12 @@ class EVF_Shortcode_Form {
 					if ( empty( $field ) || in_array( $field['type'], evf()->form_fields->get_pro_form_field_types(), true ) ) {
 						continue;
 					}
+
+					$should_display_field = apply_filters( "everest_forms_should_display_field_{$field['type']}", true, $field, $form_data );
+                    
+					if ( true !== $should_display_field ) {
+                        continue;
+                    }
 
 					// Get field attributes.
 					$attributes = self::get_field_attributes( $field, $form_data );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Fix paypal redirection issue using jquery but later on it was automatically fixed while fixing credit card label issue which you can find over here https://github.com/wpeverest/everest-forms-pro/pull/324
Closes # .

### How to test the changes in this Pull Request:

1.Create  a payment form with Paypal enabled as a payment gateway
2 Try making the payent using ajax method
3.Successfully works 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
