### PR TITLE
Fixed -  CSV textarea contents  line break issue

### DIFF
--- a/includes/export/class-evf-entry-csv-exporter.php
+++ b/includes/export/class-evf-entry-csv-exporter.php
@@ -275,11 +275,31 @@ class EVF_Entry_CSV_Exporter extends EVF_CSV_Exporter {
 				$value     = $this->{"get_column_value_{$column_id}"}( $entry );
 				$raw_value = $value;
 			}
-
-			$row[ $column_id ] = apply_filters( 'everest_forms_format_csv_field_data', sanitize_text_field( $value ), $raw_value, $column_id, $column_name, $columns, $entry );
+			$column_type       = $this->get_entry_type( $column_id, $entry );
+			$row[ $column_id ] = apply_filters( 'everest_forms_format_csv_field_data', preg_match( '/textarea/', $column_type ) ? sanitize_textarea_field( $value ) : sanitize_text_field( $value ), $raw_value, $column_id, $column_name, $columns, $entry );
 		}
 
 		return apply_filters( 'everest_forms_entry_export_row_data', $row, $entry );
+	}
+
+	/**
+	 * Get entry type.
+	 *
+	 * @param  string $column_id meta key of the column.
+	 * @param  object $entry Entry being exported.
+	 * @return string
+	 */
+	protected function get_entry_type( $column_id, $entry ) {
+		$fields = json_decode( $entry->fields, 1 );
+		if ( is_null( $fields ) || ! is_array( $fields ) ) {
+			return false; // Conditional false with fake values.
+		}
+		foreach ( $fields as $field ) {
+			if ( $column_id === $field['meta_key'] ) {
+				return $field['type'];
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In CSV file - Textarea contents hasn't been formatted properly as there was no line break in the paragraph. 
This issue has been solved in this PR.

### How to test the changes in this Pull Request:

1. Submit EverestFrom
2. Navigate to Entries
3. Download file in CSV.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fixed -  CSV textarea contents  line break issue
