### PR TITLE
EVF-65 Fix - Global Setting Import Export

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -272,8 +272,57 @@
 					message_string = '<div id="message" class="error inline everest-froms-import_notice"><p><strong>' + response.responseJSON.data.message + '</strong></p></div>';
 				}
 
-				$( '.everest-forms-import-form' ).find( 'h3' ).after( message_string );
+				$( '.everest-forms-import-form-settings' ).find( 'h3' ).after( message_string );
 				$( '#everest-forms-import' ).val( '' );
+				$( '#import-file-name' ).html( '' );
+			}
+		});
+	});
+
+	// Change span with file name when user selects a file.
+	$( '#everest-forms-global-settings-import' ).on( 'change', function(e) {
+		var file = $( '#everest-forms-global-settings-import' ).prop( 'files' )[0];
+
+		$( '#import-settings-file-name' ).html( file.name );
+	});
+	
+	// Global Settings import actions.
+	$( '.everest_forms_global_settings_import_action' ).on( 'click', function() {
+		var file_data = $( '#everest-forms-global-settings-import' ).prop( 'files' )[0],
+		form_data = new FormData();
+
+		form_data.append( 'jsonfile', file_data );
+		form_data.append( 'action', 'everest_forms_import_global_settings_action' );
+		form_data.append( 'security', everest_forms_admin.ajax_import_nonce );
+
+		$.ajax({
+			url: evf_email_params.ajax_url,
+			dataType: 'json', // JSON type is expected back from the PHP script.
+			cache: false,
+			contentType: false,
+			processData: false,
+			data: form_data,
+			type: 'POST',
+			beforeSend: function () {
+				var spinner = '<i class="evf-loading evf-loading-active"></i>';
+				$( '.everest_forms_global_settings_import_action' ).closest( '.everest_forms_global_settings_import_action' ).append( spinner );
+				$( '.everest-froms-import_notice' ).remove();
+			},
+			complete: function( response ) {
+				var message_string = '';
+
+				$( '.everest_forms_global_settings_import_action' ).closest( '.everest_forms_global_settings_import_action' ).find( '.evf-loading' ).remove();
+				$( '.everest-froms-import_notice' ).remove();
+
+				if ( true === response.responseJSON.success ) {
+					message_string = '<div id="message" class="updated inline everest-froms-import_notice"><p><strong>' + response.responseJSON.data.message + '</strong></p></div>';
+				} else {
+					message_string = '<div id="message" class="error inline everest-froms-import_notice"><p><strong>' + response.responseJSON.data.message + '</strong></p></div>';
+				}
+
+				$( '.everest-forms-import-global-settings' ).find( 'h3' ).after( message_string );
+				$( '#everest-forms-global-settings-import' ).val( '' );
+				$( '#import-settings-file-name' ).html( '' );
 			}
 		});
 	});

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Welcome page redirection on every plugin updates.
 * Fix - CSV textarea contents line break issue.
 * Fix - Form Field deletion with delete button.
+* Enhancement - Added Global Settings Import/Export.
 
 
 = 1.7.4 - 11-03-2021 =

--- a/includes/admin/class-evf-admin-settings.php
+++ b/includes/admin/class-evf-admin-settings.php
@@ -780,6 +780,37 @@ if ( ! class_exists( 'EVF_Admin_Settings', false ) ) :
 
 			return true;
 		}
+
+		/**
+		 * Get Global Settings.
+		 */
+		public static function get_global_settings() {
+			$global_settings = array();
+			$defalt_settings = self::get_settings_pages();
+			foreach ( $defalt_settings as $setting_obj ) {
+				// Setting option for specific setting page/UI.
+				$setting = $setting_obj->get_settings();
+				foreach ( $setting as $set ) {
+					$global_settings[ $set['id'] ] = self::get_option( $set['id'], $set['default'] );
+				}
+			}
+			return $global_settings;
+		}
+
+		/**
+		 * Save Global Settings.
+		 *
+		 * @param array $settings Imported setting array.
+		 */
+		public static function save_global_settings( $settings ) {
+			$defalt_settings = self::get_settings_pages();
+			$options         = array();
+			foreach ( $defalt_settings as $setting_obj ) {
+				$setting = $setting_obj->get_settings();
+				$options = array_merge( $options, $setting );
+			}
+			return self::save_fields( $options, $settings );
+		}
 	}
 
 endif;

--- a/includes/admin/views/html-admin-page-export.php
+++ b/includes/admin/views/html-admin-page-export.php
@@ -8,8 +8,26 @@
 defined( 'ABSPATH' ) || exit;
 
 ?>
+<style>
+	.everest-forms-export-form {
+		background-color: inherit;
+		border: none;
+		box-shadow: none;	
+	}
+	.everest-forms-export-form .publishing-action {
+		border: none;
+		text-align: left;
+	}
+	div.divider {
+		height: 1px;
+		width: 100%;
+		background-color: #cccccc;
+	}
+
+</style>
+
 <div class="everest-forms-export-form">
-	<h3><?php esc_html_e( 'Export Everest Forms with Settings', 'everest-forms' ); ?></h3>
+	<h3><?php esc_html_e( 'Export individual form settings', 'everest-forms' ); ?></h3>
 	<p><?php esc_html_e( 'Export your forms along with their settings as JSON file.', 'everest-forms' ); ?></p>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=evf-tools&tab=export' ) ); ?>">
 		<?php
@@ -27,6 +45,24 @@ defined( 'ABSPATH' ) || exit;
 		<div class="publishing-action">
 			<?php wp_nonce_field( 'everest_forms_export_nonce', 'everest-forms-export-nonce' ); ?>
 			<button type="submit" class="everest-forms-btn everest-forms-btn-primary everest-forms-export-form-action" name="everest-forms-export-form"><?php esc_html_e( 'Export', 'everest-forms' ); ?></button>
+		</div>
+	</form>
+</div>
+
+<div class="divider"></div>
+
+<div class="everest-forms-export-form everest-forms-export-settings">
+	<h3><?php esc_html_e( 'Export global settings', 'everest-forms' ); ?></h3>
+	<p><?php esc_html_e( 'Export your global settings as JSON file.', 'everest-forms' ); ?></p>
+	<?php
+	if ( defined( 'EFP_VERSION' ) ) {
+		?>
+		<p><?php esc_html_e( 'Integration settings will not be exported as they require authentication.', 'everest-forms' ); ?></p>
+	<?php } ?>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=evf-tools&tab=export' ) ); ?>">
+		<div class="publishing-action">
+			<?php wp_nonce_field( 'everest_forms_global_export_nonce', 'everest-forms-global-export-nonce' ); ?>
+			<button type="submit" class="everest-forms-btn everest-forms-btn-primary everest-forms-global-setting-export" name="everest-forms-global-setting-export"><?php esc_html_e( 'Export', 'everest-forms' ); ?></button>
 		</div>
 	</form>
 </div>

--- a/includes/admin/views/html-admin-page-import.php
+++ b/includes/admin/views/html-admin-page-import.php
@@ -8,7 +8,26 @@
 defined( 'ABSPATH' ) || exit;
 
 ?>
-<div class="everest-forms-import-form">
+
+<style>
+	.everest-forms-import-form {
+		background-color: inherit;
+		border: none;
+		box-shadow: none;	
+	}
+	.everest-forms-import-form .publishing-action {
+		border: none;
+		text-align: left;
+	}
+	div.divider {
+		height: 1px;
+		width: 100%;
+		background-color: #cccccc;
+
+	}
+
+</style>
+<div class="everest-forms-import-form everest-forms-import-form-settings">
 	<h3><?php esc_html_e( 'Import Everest Forms', 'everest-forms' ); ?></h3>
 	<p><?php esc_html_e( 'Select JSON file to import the form.', 'everest-forms' ); ?></p>
 	<div class="everest-forms-file-upload">
@@ -25,5 +44,25 @@ defined( 'ABSPATH' ) || exit;
 	<div class="publishing-action">
 		<button type="submit" class="everest-forms-btn everest-forms-btn-primary everest_forms_import_action" name="everest-forms-import-form"><?php esc_html_e( 'Import Form', 'everest-forms' ); ?></button>
 		<?php wp_nonce_field( 'everest_forms_import_nonce', 'everest-forms-import-nonce' ); ?>
+	</div>
+</div>
+<div class="divider"></div>
+<div class="everest-forms-import-form everest-forms-import-global-settings">
+	<h3><?php esc_html_e( 'Import Everest Forms Global Settings', 'everest-forms' ); ?></h3>
+	<p><?php esc_html_e( 'Select JSON file to import the settngs.', 'everest-forms' ); ?></p>
+	<div class="everest-forms-file-upload">
+		<input type="file" name="file" id="everest-forms-global-settings-import" <?php esc_attr_e( 'files selected', 'everest-forms' ); ?>" accept=".json" />
+		<label for="everest-forms-global-settings-import"><span class="everest-forms-btn dashicons dashicons-upload">Choose File</span><span id="import-settings-file-name"><?php esc_html_e( 'No file selected', 'everest-forms' ); ?></span></label>
+	</div>
+	<p class="description">
+		<i class="dashicons dashicons-info"></i>
+		<?php
+		/* translators: %s: File format */
+		printf( esc_html__( 'Only %s file is allowed.', 'everest-forms' ), '<strong>JSON</strong>' );
+		?>
+	</p>
+	<div class="publishing-action">
+		<button type="submit" class="everest-forms-btn everest-forms-btn-primary everest_forms_global_settings_import_action" name="everest-forms-global-settings-import"><?php esc_html_e( 'Import Settings', 'everest-forms' ); ?></button>
+		<?php wp_nonce_field( 'everest_forms_global_settings_import_nonce', 'everest-forms-global-settings-import-nonce' ); ?>
 	</div>
 </div>

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -82,21 +82,22 @@ class EVF_AJAX {
 	 */
 	public static function add_ajax_events() {
 		$ajax_events = array(
-			'save_form'               => false,
-			'create_form'             => false,
-			'get_next_id'             => false,
-			'install_extension'       => false,
-			'integration_connect'     => false,
-			'new_email_add'           => false,
-			'integration_disconnect'  => false,
-			'deactivation_notice'     => false,
-			'rated'                   => false,
-			'review_dismiss'          => false,
-			'enabled_form'            => false,
-			'import_form_action'      => false,
-			'template_licence_check'  => false,
-			'template_activate_addon' => false,
-			'ajax_form_submission'    => true,
+			'save_form'                     => false,
+			'create_form'                   => false,
+			'get_next_id'                   => false,
+			'install_extension'             => false,
+			'integration_connect'           => false,
+			'new_email_add'                 => false,
+			'integration_disconnect'        => false,
+			'deactivation_notice'           => false,
+			'rated'                         => false,
+			'review_dismiss'                => false,
+			'enabled_form'                  => false,
+			'import_form_action'            => false,
+			'import_global_settings_action' => false,
+			'template_licence_check'        => false,
+			'template_activate_addon'       => false,
+			'ajax_form_submission'          => true,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -701,6 +702,22 @@ class EVF_AJAX {
 		try {
 			check_ajax_referer( 'process-import-ajax-nonce', 'security' );
 			EVF_Admin_Import_Export::import_form();
+		} catch ( Exception $e ) {
+			wp_send_json_error(
+				array(
+					'message' => $e->getMessage(),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Import EVF Global Settings
+	 */
+	public static function import_global_settings_action() {
+		try {
+			check_ajax_referer( 'process-import-ajax-nonce', 'security' );
+			EVF_Admin_Import_Export::import_global_settings();
 		} catch ( Exception $e ) {
 			wp_send_json_error(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR allows user to import or export EVF global settings.

### How to test the changes in this Pull Request:

1. Navigate to EVF Tools.
2. From the Export Tab, export global settings.
3. Navigate to EVF Tools of another site in which you want to apply settings.
4. From Import Tab, import the global settings.
5. Verify the settings changes.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Global Setting Import Export