### PR TITLE
Fix - Payment Multiple choices and checkboxes fields amount preview

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -644,7 +644,7 @@
 			});
 
 			// Updates field choices text in almost real time.
-			$builder.on( 'keyup paste focusout', '.everest-forms-field-option-row-choices input.label', function(e) {
+			$builder.on( 'keyup paste focusout', '.everest-forms-field-option-row-choices input.label , .everest-forms-field-option-row-choices input.value', function(e) {
 				var list = $(this).parent().parent().parent();
 				EVFPanelBuilder.choiceUpdate( list.data( 'field-type' ), list.data( 'field-id' ) );
 			});
@@ -1018,6 +1018,7 @@
 						type:     type,
 						order:    choices,
 						settings: settings,
+						amountFilter: EVFPanelBuilder.amountFilter,
 					};
 
 				$( '#everest-forms-field-' + id ).find( 'ul.primary-input' ).replaceWith( tmpl( data ) );
@@ -1057,6 +1058,16 @@
 				}
 			} );
 		},
+
+		amountFilter: function(data, amount){
+			if ( 'right' === data.currency_symbol_pos ) {
+				singleItem = amount + ' ' + data.currency_symbol;
+			} else {
+				singleItem = data.currency_symbol + ' ' + amount;
+			}
+			return singleItem;
+		},
+
 		bindFormSettings: function () {
 			$( 'body' ).on( 'click', '.evf-setting-panel', function( e ) {
 				var data_setting_section = $(this).attr('data-section');

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -644,7 +644,7 @@
 			});
 
 			// Updates field choices text in almost real time.
-			$builder.on( 'keyup paste focusout', '.everest-forms-field-option-row-choices input.label , .everest-forms-field-option-row-choices input.value', function(e) {
+			$builder.on( 'keyup paste focusout', '.everest-forms-field-option-row-choices input.label, .everest-forms-field-option-row-choices input.value', function(e) {
 				var list = $(this).parent().parent().parent();
 				EVFPanelBuilder.choiceUpdate( list.data( 'field-type' ), list.data( 'field-id' ) );
 			});
@@ -1061,11 +1061,10 @@
 
 		amountFilter: function(data, amount){
 			if ( 'right' === data.currency_symbol_pos ) {
-				singleItem = amount + ' ' + data.currency_symbol;
+				return amount + ' ' + data.currency_symbol;
 			} else {
-				singleItem = data.currency_symbol + ' ' + amount;
+				return data.currency_symbol + ' ' + amount;
 			}
-			return singleItem;
 		},
 
 		bindFormSettings: function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Welcome page redirection on every plugin updates.
 * Fix - New Email Notifications not being saved on reload.
 * Fix - New Email Notifications cloned blank for assigned values.
+* Fix - Payment Multiple choices and checkboxes fields amount preview in form builder area.
 
 = 1.7.4 - 11-03-2021 =
 * Fix - Hide empty select data field from entry view.

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -780,11 +780,11 @@ abstract class EVF_Form_Fields {
 
 					$active_type = ! empty( $field['multiple_choices'] ) && '1' === $field['multiple_choices'] ? 'multiple' : 'single';
 					foreach ( $selection_types as $key => $selection_type ) {
-						$selection_btn[ $key ] = '<span data-selection="' . esc_attr( $key ) . '" data-type="' . esc_attr( $selection_type['type'] ) . '" class="everest-forms-btn flex ' . ( $active_type === $key ? 'is-active' : '' ) . ' ' . ( false === $licensed && 'multiple' === $key ? 'upgrade-modal' : '' ) . '" data-feature="' . esc_html__( 'Multiple selection', 'everest-forms' ) . '">' . esc_html( $selection_type['label'] ) . '</span>';
+						$selection_btn[ $key ] = '<span data-selection="' . esc_attr( $key ) . '" data-type="' . esc_attr( $selection_type['type'] ) . '" class="flex everest-forms-btn ' . ( $active_type === $key ? 'is-active' : '' ) . ' ' . ( false === $licensed && 'multiple' === $key ? 'upgrade-modal' : '' ) . '" data-feature="' . esc_html__( 'Multiple selection', 'everest-forms' ) . '">' . esc_html( $selection_type['label'] ) . '</span>';
 					}
 
 					$field_content .= sprintf(
-						'<div class="everest-forms-btn-group flex everest-forms-btn-group--inline"><input type="hidden" id="everest-forms-field-option-%1$s-multiple_choices" name="form_fields[%1$s][multiple_choices]" value="%2$s" />%3$s</div>',
+						'<div class="flex everest-forms-btn-group everest-forms-btn-group--inline"><input type="hidden" id="everest-forms-field-option-%1$s-multiple_choices" name="form_fields[%1$s][multiple_choices]" value="%2$s" />%3$s</div>',
 						esc_attr( $field['id'] ),
 						! empty( $field['multiple_choices'] ) && '1' === $field['multiple_choices'] ? 1 : 0,
 						implode( '', $selection_btn )
@@ -1425,8 +1425,7 @@ abstract class EVF_Form_Fields {
 					$output = sprintf( '<ul class="%s">', evf_sanitize_classes( $list_class, true ) );
 
 					// Individual checkbox/radio options.
-					foreach ( $values as $key => $value ) {
-						$form_id     = isset( $_GET['form_id'] ) ? (int) $_GET['form_id'] : ''; // phpcs:ignore WordPress.Security.NonceVerification
+					foreach ( $values as $value ) {
 						$default     = isset( $value['default'] ) ? $value['default'] : '';
 						$selected    = checked( '1', $default, false );
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
@@ -1446,16 +1445,16 @@ abstract class EVF_Form_Fields {
 						if ( $choices_images ) {
 							$output .= '<label>';
 							$output .= sprintf( '<span class="everest-forms-image-choices-image"><img src="%s" alt="%s"%s></span>', $image_src, esc_attr( $value['label'] ), ! empty( $value['label'] ) ? ' title="' . esc_attr( $value['label'] ) . '"' : '' );
+							$output .= sprintf( '<input type="%s" %s disabled>', $type, $selected );
 							if ( ( 'payment-checkbox' === $field['type'] ) || ( 'payment-multiple' === $field['type'] ) ) {
-								$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+								$output .= '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '-' . evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) . '</span>';
 							} else {
-								$output .= sprintf( '<input type="%s" %s disabled>', $type, $selected );
 								$output .= '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>';
 							}
 							$output .= '</label>';
 						} else {
 							if ( ( 'payment-checkbox' === $field['type'] ) || ( 'payment-multiple' === $field['type'] ) ) {
-								$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+								$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, $value['label'], evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 							} else {
 								$output .= sprintf( '<input type="%s" %s disabled>%s', $type, $selected, $value['label'] );
 							}

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1431,6 +1431,7 @@ abstract class EVF_Form_Fields {
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
 						$image_src   = ! empty( $value['image'] ) ? esc_url( $value['image'] ) : $placeholder;
 						$item_class  = array();
+						$form_id = (isset($_GET['form_id']) && !empty($_GET['form_id']))?$_GET['form_id']:'';
 
 						if ( ! empty( $value['default'] ) ) {
 							$item_class[] = 'everest-forms-selected';
@@ -1445,12 +1446,9 @@ abstract class EVF_Form_Fields {
 						if ( $choices_images ) {
 							$output .= '<label>';
 							$output .= sprintf( '<span class="everest-forms-image-choices-image"><img src="%s" alt="%s"%s></span>', $image_src, esc_attr( $value['label'] ), ! empty( $value['label'] ) ? ' title="' . esc_attr( $value['label'] ) . '"' : '' );
-							$output .= sprintf( '<input type="%s" %s disabled>', $type, $selected );
-							$output .= '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>';
+							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ),  evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 							$output .= '</label>';
 						} else {
-							// Modified by Jack Rourke
-							$form_id = (isset($_GET['form_id']) && !empty($_GET['form_id']))?$_GET['form_id']:'';
 							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ),  evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 						}
 

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1431,7 +1431,10 @@ abstract class EVF_Form_Fields {
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
 						$image_src   = ! empty( $value['image'] ) ? esc_url( $value['image'] ) : $placeholder;
 						$item_class  = array();
-						$form_id = (isset($_GET['form_id']) && !empty($_GET['form_id']))?$_GET['form_id']:'';
+						// @codingStandardsIgnoreStart
+						$form_id     = wp_unslash( $_GET['form_id'] );
+						$form_id     = ( isset( $form_id ) && ! empty( $form_id ) ) ? $form_id : '';
+						// @codingStandardsIgnoreEnd
 
 						if ( ! empty( $value['default'] ) ) {
 							$item_class[] = 'everest-forms-selected';
@@ -1446,10 +1449,10 @@ abstract class EVF_Form_Fields {
 						if ( $choices_images ) {
 							$output .= '<label>';
 							$output .= sprintf( '<span class="everest-forms-image-choices-image"><img src="%s" alt="%s"%s></span>', $image_src, esc_attr( $value['label'] ), ! empty( $value['label'] ) ? ' title="' . esc_attr( $value['label'] ) . '"' : '' );
-							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ),  evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 							$output .= '</label>';
 						} else {
-							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ),  evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 						}
 
 						$output .= '</li>';

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1431,9 +1431,9 @@ abstract class EVF_Form_Fields {
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
 						$image_src   = ! empty( $value['image'] ) ? esc_url( $value['image'] ) : $placeholder;
 						$item_class  = array();
+
 						// @codingStandardsIgnoreStart
-						$form_id     = wp_unslash( $_GET['form_id'] );
-						$form_id     = ( isset( $form_id ) && ! empty( $form_id ) ) ? $form_id : '';
+						$form_id     = ( isset( $_GET['form_id'] ) && ! empty( $_GET['form_id'] ) ) ? $_GET['form_id'] : '';
 						// @codingStandardsIgnoreEnd
 
 						if ( ! empty( $value['default'] ) ) {
@@ -1449,10 +1449,19 @@ abstract class EVF_Form_Fields {
 						if ( $choices_images ) {
 							$output .= '<label>';
 							$output .= sprintf( '<span class="everest-forms-image-choices-image"><img src="%s" alt="%s"%s></span>', $image_src, esc_attr( $value['label'] ), ! empty( $value['label'] ) ? ' title="' . esc_attr( $value['label'] ) . '"' : '' );
-							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							if ( ( 'payment-checkbox' === $field['type'] ) || ( 'payment-multiple' === $field['type'] ) ) {
+								$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>', '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							} else {
+								$output .= sprintf( '<input type="%s" %s disabled>', $type, $selected );
+								$output .= '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>';
+							}
 							$output .= '</label>';
 						} else {
-							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							if ( ( 'payment-checkbox' === $field['type'] ) || ( 'payment-multiple' === $field['type'] ) ) {
+								$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ), evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
+							} else {
+								$output .= sprintf( '<input type="%s" %s disabled>%s', $type, $selected, $value['label'] );
+							}
 						}
 
 						$output .= '</li>';

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1426,15 +1426,12 @@ abstract class EVF_Form_Fields {
 
 					// Individual checkbox/radio options.
 					foreach ( $values as $key => $value ) {
+						$form_id     = isset( $_GET['form_id'] ) ? (int) $_GET['form_id'] : ''; // phpcs:ignore WordPress.Security.NonceVerification
 						$default     = isset( $value['default'] ) ? $value['default'] : '';
 						$selected    = checked( '1', $default, false );
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
 						$image_src   = ! empty( $value['image'] ) ? esc_url( $value['image'] ) : $placeholder;
 						$item_class  = array();
-
-						// @codingStandardsIgnoreStart
-						$form_id     = ( isset( $_GET['form_id'] ) && ! empty( $_GET['form_id'] ) ) ? $_GET['form_id'] : '';
-						// @codingStandardsIgnoreEnd
 
 						if ( ! empty( $value['default'] ) ) {
 							$item_class[] = 'everest-forms-selected';

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1425,7 +1425,7 @@ abstract class EVF_Form_Fields {
 					$output = sprintf( '<ul class="%s">', evf_sanitize_classes( $list_class, true ) );
 
 					// Individual checkbox/radio options.
-					foreach ( $values as $value ) {
+					foreach ( $values as $key => $value ) {
 						$default     = isset( $value['default'] ) ? $value['default'] : '';
 						$selected    = checked( '1', $default, false );
 						$placeholder = evf()->plugin_url() . '/assets/images/everest-forms-placeholder.png';
@@ -1449,7 +1449,9 @@ abstract class EVF_Form_Fields {
 							$output .= '<span class="everest-forms-image-choices-label">' . wp_kses_post( $value['label'] ) . '</span>';
 							$output .= '</label>';
 						} else {
-							$output .= sprintf( '<input type="%s" %s disabled>%s', $type, $selected, $value['label'] );
+							// Modified by Jack Rourke
+							$form_id = (isset($_GET['form_id']) && !empty($_GET['form_id']))?$_GET['form_id']:'';
+							$output .= sprintf( '<input type="%s" %s disabled>%s - %s', $type, $selected, evf_string_translation( $form_id, $field['id'], $value['label'], '-choice-' . $key ),  evf_format_amount( evf_sanitize_amount( $value['value'] ), true ) );
 						}
 
 						$output .= '</li>';

--- a/includes/admin/views/html-admin-page-builder.php
+++ b/includes/admin/views/html-admin-page-builder.php
@@ -92,7 +92,7 @@ $preview_link = add_query_arg(
 							<# } #>
 						</span>
 						<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>
-						<span class="everest-forms-image-choices-label">{{{ data.settings.choices[choiceID].label + ' - '+ data.amountFilter( evf_data, data.settings.choices[choiceID].value ) }}}</span>
+						<span class="everest-forms-image-choices-label">{{{ data.settings.choices[choiceID].label }}} <# if(( 'payment-checkbox' === data.settings.type ) || ( 'payment-multiple' === data.settings.type )) { print ( ' - ' + data.amountFilter( evf_data, data.settings.choices[choiceID].value )) }#></span>
 					</label>
 				</li>
 			<# }) #>

--- a/includes/admin/views/html-admin-page-builder.php
+++ b/includes/admin/views/html-admin-page-builder.php
@@ -92,7 +92,7 @@ $preview_link = add_query_arg(
 							<# } #>
 						</span>
 						<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>
-						<span class="everest-forms-image-choices-label">{{{ data.settings.choices[choiceID].label }}}</span>
+						<span class="everest-forms-image-choices-label">{{{ data.settings.choices[choiceID].label + ' - '+ data.amountFilter( evf_data, data.settings.choices[choiceID].value ) }}}</span>
 					</label>
 				</li>
 			<# }) #>

--- a/includes/admin/views/html-admin-page-builder.php
+++ b/includes/admin/views/html-admin-page-builder.php
@@ -101,7 +101,7 @@ $preview_link = add_query_arg(
 		<ul class="widefat primary-input">
 			<# _.each( data.order, function( choiceID, key ) {  #>
 				<li>
-					<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>{{{ data.settings.choices[choiceID].label }}}
+					<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>{{{ data.settings.choices[choiceID].label + ' - '+ data.amountFilter( evf_data, data.settings.choices[choiceID].value ) }}}
 				</li>
 			<# }) #>
 		</ul>

--- a/includes/admin/views/html-admin-page-builder.php
+++ b/includes/admin/views/html-admin-page-builder.php
@@ -101,7 +101,7 @@ $preview_link = add_query_arg(
 		<ul class="widefat primary-input">
 			<# _.each( data.order, function( choiceID, key ) {  #>
 				<li>
-					<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>{{{ data.settings.choices[choiceID].label + ' - '+ data.amountFilter( evf_data, data.settings.choices[choiceID].value ) }}}
+					<input type="{{ data.type }}" disabled<# if ( 1 === data.settings.choices[choiceID].default ) { print( ' checked' ); } #>>{{{ data.settings.choices[choiceID].label }}} <# if(( 'payment-checkbox' === data.settings.type ) || ( 'payment-multiple' === data.settings.type )) { print ( ' - ' + data.amountFilter( evf_data, data.settings.choices[choiceID].value )) }#>
 				</li>
 			<# }) #>
 		</ul>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously there was no preview detail for amount in the payment field. This PR adds a feature to show the preview for amount changes in the fields for payment multiple choices and checkboxes fields.

### How to test the changes in this Pull Request:

1. Add Multiple Choices and Checkboxes of Payment field.
2. Make some changes for amount in field option and verify if it is updated in corresponding fields in form builder area.
3. That's all, if the amount is updated in the form builder area then this PR is working fine.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Payment Multiple choices and checkboxes fields amount preview in form builder area.
