### PR TITLE
Fix - Get entries permission issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.7.6 - xx-xx-xxxx =
+* Fix - Get entries permission issue.
+
 = 1.7.5.2 - 19-06-2021 =
 * Fix - Permission issue with file upload on frontend.
 * Fix - Dropdown field value not displayed on view entry page.

--- a/includes/evf-entry-functions.php
+++ b/includes/evf-entry-functions.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 function evf_get_entry( $id, $with_fields = false, $args = array() ) {
 	global $wpdb;
 
-	if ( ! isset( $args['cap'] ) ) {
+	if ( ! isset( $args['cap'] ) && is_admin() ) {
 		$args['cap'] = 'everest_forms_view_entry';
 	}
 

--- a/includes/evf-entry-functions.php
+++ b/includes/evf-entry-functions.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 function evf_get_entry( $id, $with_fields = false, $args = array() ) {
 	global $wpdb;
 
-	if ( ! isset( $args['cap'] ) && is_admin() ) {
+	if ( ! isset( $args['cap'] ) && ( is_admin() && ! wp_doing_ajax() ) ) {
 		$args['cap'] = 'everest_forms_view_entry';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

 Get entries permission issue. Its causing PDF image not being formatted as expected.

### How to test the changes in this Pull Request:

1. Create form
2. Add Image fields
2. Enable PDF attachment 
3. Submit form
4. Very image in Email PDF.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Get entries permission issue
