### PR TITLE
Fix - Pagination not working in admin forms list table

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.7.6 - xx-xx-2021 =
 * Enhancement - Cache the form and entries results for better performance.
+* Fix - Pagination not working in admin forms list table.
 * Fix - Attach pdf to email glitches.
 * Fix - Get entries permission issue.
 * Fix - Smart Tag Page Issues.

--- a/includes/admin/class-evf-admin-forms-table-list.php
+++ b/includes/admin/class-evf-admin-forms-table-list.php
@@ -534,6 +534,7 @@ class EVF_Admin_Forms_Table_List extends WP_List_Table {
 
 		// Query args.
 		$args = array(
+			'post_type' => 'everest_form',
 			'posts_per_page'      => $per_page,
 			'paged'               => $current_page,
 			'no_found_rows'       => false,
@@ -554,14 +555,16 @@ class EVF_Admin_Forms_Table_List extends WP_List_Table {
 		$args['order']   = isset( $_REQUEST['order'] ) && 'ASC' === strtoupper( evf_clean( wp_unslash( $_REQUEST['order'] ) ) ) ? 'ASC' : 'DESC'; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Get the forms.
-		$this->items = evf()->form->get_multiple( $args );
+		// $this->items = evf()->form->get_multiple( $args );
+		$posts       = new WP_Query( $args );
+		$this->items = $posts->posts;
 
 		// Set the pagination.
 		$this->set_pagination_args(
 			array(
-				'total_items' => $total,
+				'total_items' => $posts->found_posts,
 				'per_page'    => $per_page,
-				'total_pages' => ceil( $total / $per_page ),
+				'total_pages' => $posts->max_num_pages,
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the per page limit and pagination issues as well as the problem of duplicate entries in QM.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Apply view forms and view others forms' roles to any extra user also.
3. Now test pagination and forms listing capabilities. Capability shouldn't get broken!!
4. See the duplicate queries section in QM. It should be now cleared. and a big Hurray!!!

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Pagination not working in admin forms list table.
