### PR TITLE
Fix - Default Value for Payment Quantity Field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.7.7 - xx-xx-2021 =
 * Tweak - Spacing issue on upgrade modal dialogues.
+* Fix - Default Field for Payment Quantity.
 
 = 1.7.6 - 28-07-2021 =
 * Enhancement - Cache the form and entries results for better performance.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 1.7.7 - xx-xx-2021 =
 * Tweak - Spacing issue on upgrade modal dialogues.
-* Fix - Default Field for Payment Quantity.
+* Fix - Default Value for Payment Quantity Field.
 
 = 1.7.6 - 28-07-2021 =
 * Enhancement - Cache the form and entries results for better performance.

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1079,7 +1079,7 @@ abstract class EVF_Form_Fields {
 				);
 
 				// Smart tag for default value.
-				$exclude_fields = array( 'rating', 'number', 'range-slider' );
+				$exclude_fields = array( 'rating', 'number', 'range-slider', 'payment-quantity' );
 
 				if ( ! in_array( $field['type'], $exclude_fields, true ) ) {
 					$output .= '<a href="#" class="evf-toggle-smart-tag-display" data-type="other"><span class="dashicons dashicons-editor-code"></span></a>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously there was the absence of the **Default Value** in the **Quantity Field** on **Payment Fields**. This PR helps to include the default value for the Payment Quantity field.

### Dependent PR:
https://github.com/wpeverest/everest-forms-pro/pull/389

### How to test the changes in this Pull Request:

1. Open **Form Builder** for a particular form.
2. Drag and Drop **Quantity** field from **Payment** Fields or select any existing **Quantity Field**.
3. Go to **Field Options** for that particular **Quantity Field** and open **Advance Options**.
4. That's all. You can now see the **Default Value** option for the **Quantity Field** as well.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Default Field for Payment Quantity.