### PR TITLE
Fix - Calendar not showing when enable min and max Date

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2643,30 +2643,33 @@ jQuery( function ( $ ) {
 		}
 	});
 
+
 	$( document ).on( 'click', '.everest-forms-min-max-date-format input', function() {
+		var minDate = $( this ).closest( '.everest-forms-date' ).find( '.everest-forms-min-date' ).val();
+		var maxDate = $(this).closest('.everest-forms-date').find('.everest-forms-min-date').val();
 		if ( $( this ).is( ':checked' ) ) {
 			$( '.everest-forms-min-max-date-option' ).removeClass( 'everest-forms-hidden' );
-				if('' === $('.everest-forms-min-date').val()){
+				if( '' === minDate ){
 					$('.everest-forms-min-date').addClass('flatpickr-field').flatpickr({
 						disableMobile : true,
 						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
-							$('.everest-forms-min-date').val(dateStr);
+							$( '.everest-forms-min-date' ).val(dateStr);
 						},
 						onOpen: function(selectedDates, dateStr, instance) {
 							instance.set('maxDate', $('.everest-forms-max-date').val());
 						},
 					});
 				}
-				if('' === $('.everest-forms-max-date').val() ){
-					$('.everest-forms-max-date').addClass('flatpickr-field').flatpickr({
+				if('' === maxDate ){
+					$( '.everest-forms-max-date' ).addClass( 'flatpickr-field' ).flatpickr({
 						disableMobile : true,
 						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
-							$('.everest-forms-max-date').val(dateStr);
+							$( '.everest-forms-max-date' ).val(dateStr);
 						},
 						onOpen: function(selectedDates, dateStr, instance) {
-							instance.set('minDate', $('.everest-forms-min-date').val());
+							instance.set('minDate', $( '.everest-forms-min-date' ).val());
 						},
 					});
 				}

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -24,7 +24,6 @@
 				 if( '1' === $( '.everest-forms-min-max-date-format input' ).val() ) {
 					$('.everest-forms-min-date').addClass('flatpickr-field').flatpickr({
 						disableMobile : true,
-						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
 							$('.everest-forms-min-date').val(dateStr);
 						},
@@ -35,7 +34,6 @@
 
 					$('.everest-forms-max-date').addClass('flatpickr-field').flatpickr({
 						disableMobile : true,
-						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
 							$('.everest-forms-max-date').val(dateStr);
 						},
@@ -2652,7 +2650,6 @@ jQuery( function ( $ ) {
 				if( '' === minDate ){
 					$('.everest-forms-min-date').addClass('flatpickr-field').flatpickr({
 						disableMobile : true,
-						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
 							$( '.everest-forms-min-date' ).val(dateStr);
 						},
@@ -2664,7 +2661,6 @@ jQuery( function ( $ ) {
 				if('' === maxDate ){
 					$( '.everest-forms-max-date' ).addClass( 'flatpickr-field' ).flatpickr({
 						disableMobile : true,
-						static        : true,
 						onChange      : function(selectedDates, dateStr, instance) {
 							$( '.everest-forms-max-date' ).val(dateStr);
 						},

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -19,29 +19,39 @@
 		 		}
 		 	});
 
-		 	$( document ).ready( function( $ ) {
-				if ( '1' === $( '.everest-forms-min-max-date-format input' ).val() ) {
-					$( '.everest-forms-min-max-date-option' ).find( 'input' ).datepicker({
-						defaultDate:     '',
-						dateFormat:      'yy-mm-dd',
-						numberOfMonths:  1,
-						showButtonPanel: true,
-						onSelect:        function() {
-							var option = $( this ).is( '.everest-forms-min-date' ) ? 'minDate' : 'maxDate',
-								dates  = $( this ).closest( '.everest-forms-min-max-date-option' ).find( 'input' ),
-								date   = $( this ).datepicker( 'getDate' );
 
-							dates.not( this ).datepicker( 'option', option, date );
-							$( this ).change();
-						}
-					} );
+			 $(document).ready( function( $ ) {
+				 if( '1' === $( '.everest-forms-min-max-date-format input' ).val() ) {
+					$('.everest-forms-min-date').addClass('flatpickr-field').flatpickr({
+						disableMobile : true,
+						static        : true,
+						onChange      : function(selectedDates, dateStr, instance) {
+							$('.everest-forms-min-date').val(dateStr);
+						},
+						onOpen: function(selectedDates, dateStr, instance) {
+							instance.set('maxDate', $('.everest-forms-max-date').val());
+						},
+					});
+
+					$('.everest-forms-max-date').addClass('flatpickr-field').flatpickr({
+						disableMobile : true,
+						static        : true,
+						onChange      : function(selectedDates, dateStr, instance) {
+							$('.everest-forms-max-date').val(dateStr);
+						},
+						onOpen: function(selectedDates, dateStr, instance) {
+							instance.set('minDate', $('.everest-forms-min-date').val());
+						},
+					});
 				}
+			});
+
 
 		 		if ( ! $( 'evf-panel-payments-button a' ).hasClass( 'active' ) ) {
 		 			$( '#everest-forms-panel-payments' ).find( '.everest-forms-panel-sidebar a' ).first().addClass( 'active' );
 					$( '.everest-forms-panel-content' ).find( '.evf-payment-setting-content' ).first().addClass( 'active' );
 				}
-		 	});
+
 
 			// Copy shortcode from the builder.
 		 	$( document.body ).find('#copy-shortcode' )
@@ -2636,8 +2646,32 @@ jQuery( function ( $ ) {
 	$( document ).on( 'click', '.everest-forms-min-max-date-format input', function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$( '.everest-forms-min-max-date-option' ).removeClass( 'everest-forms-hidden' );
+				if('' === $('.everest-forms-min-date').val()){
+					$('.everest-forms-min-date').addClass('flatpickr-field').flatpickr({
+						disableMobile : true,
+						static        : true,
+						onChange      : function(selectedDates, dateStr, instance) {
+							$('.everest-forms-min-date').val(dateStr);
+						},
+						onOpen: function(selectedDates, dateStr, instance) {
+							instance.set('maxDate', $('.everest-forms-max-date').val());
+						},
+					});
+				}
+				if('' === $('.everest-forms-max-date').val() ){
+					$('.everest-forms-max-date').addClass('flatpickr-field').flatpickr({
+						disableMobile : true,
+						static        : true,
+						onChange      : function(selectedDates, dateStr, instance) {
+							$('.everest-forms-max-date').val(dateStr);
+						},
+						onOpen: function(selectedDates, dateStr, instance) {
+							instance.set('minDate', $('.everest-forms-min-date').val());
+						},
+					});
+				}
 		} else {
-			$( '.everest-forms-min-max-date-option' ).addClass( 'everest-forms-hidden' );
+			 $( '.everest-forms-min-max-date-option' ).addClass( 'everest-forms-hidden' );
 		}
 	});
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.7.9 - xx-xx-2021 =
+* Fix - Datepicker glitches in form builder.
+
 = 1.7.8 - 26-10-2021 =
 * Enhancement - Conditional logic for for submission redirection.
 * Feature - Repeater Fields. 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously, When the users click  enable min and max the calendar is not showing  and the calendar is also different from the above one. This PR fixes this issue


### How to test the changes in this Pull Request:

1. In Admin Side create a form with the date field and it's field setting go to advance options.
2. Enable/Disable Min Max Date if enabled select min-date and max-date new calendar is showing or not.
3. Check Min Date and Max Date working properly or not
4. In front end test date field is working according to settings or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Calendar not showing when enable min and max
