### PR TITLE
Fix - Radio Checkbox customization issue with image

### DIFF
--- a/includes/fields/class-evf-field-checkbox.php
+++ b/includes/fields/class-evf-field-checkbox.php
@@ -389,7 +389,7 @@ class EVF_Field_Checkbox extends EVF_Form_Fields {
 				$choice['attr']['tabindex'] = '-1';
 
 				printf( '<input type="checkbox" %s %s %s>', evf_html_attributes( $choice['id'], $choice['class'], $choice['data'], $choice['attr'] ), esc_attr( $choice['required'] ), checked( '1', $choice['default'], false ) );
-				echo '<span class="everest-forms-image-choices-label">' . wp_kses_post( $choice['label']['text'] ) . '</span>';
+				echo '<label class="everest-forms-image-choices-label">' . wp_kses_post( $choice['label']['text'] ) . '</label>';
 				echo '</label>';
 			} else {
 				// Normal display.

--- a/includes/fields/class-evf-field-radio.php
+++ b/includes/fields/class-evf-field-radio.php
@@ -320,7 +320,7 @@ class EVF_Field_Radio extends EVF_Form_Fields {
 				$choice['attr']['tabindex'] = '-1';
 
 				printf( '<input type="radio" %s %s %s>', evf_html_attributes( $choice['id'], $choice['class'], $choice['data'], $choice['attr'] ), esc_attr( $choice['required'] ), checked( '1', $choice['default'], false ) );
-				echo '<span class="everest-forms-image-choices-label">' . wp_kses_post( $choice['label']['text'] ) . '</span>';
+				echo '<label class="everest-forms-image-choices-label">' . wp_kses_post( $choice['label']['text'] ) . '</label>';
 				echo '</label>';
 			} else {
 				// Normal display.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the customization issue in radio/checkbox field with image option using style customizer. 

### How to test the changes in this Pull Request:

1. Create form with radio or checkbox.
2. Add images to the options.
3. Customize it style customizer.
4. Verify changes as expected.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Radio Checkbox customization issue with image
