### PR TITLE
Fix - Everest forms caching issue in Forms and Entries.

### DIFF
--- a/includes/class-evf-form-handler.php
+++ b/includes/class-evf-form-handler.php
@@ -40,12 +40,7 @@ class EVF_Form_Handler {
 				return false;
 			}
 
-			// Check the cache.
-			$the_post = wp_cache_get( $id, 'forms' );
-			if ( false === $the_post || empty( $the_post->post_content ) ) {
-				$the_post = get_post( absint( $id ) );
-				wp_cache_add( $id, $the_post, 'forms' );
-			}
+			$the_post = get_post( absint( $id ) );
 
 			if ( $the_post && 'everest_form' === $the_post->post_type ) {
 				$forms = empty( $args['content_only'] ) ? $the_post : evf_decode( $the_post->post_content );
@@ -115,22 +110,12 @@ class EVF_Form_Handler {
 		// For cache lets unset the cap args.
 		unset( $args['cap'] );
 
-		// Check for cache.
-		$cache_key   = EVF_Cache_Helper::get_cache_prefix( 'forms' ) . 'get_multiple_forms_' . md5( wp_json_encode( $args ) );
-		$cache_value = wp_cache_get( $cache_key, 'form_get_multiple_results' );
-
-		if ( $cache_value ) {
-			return $cache_value;
-		}
-
 		// Fetch posts.
 		$forms = get_posts( $args );
 
 		if ( $content_only ) {
 			$forms = array_map( array( $this, 'prepare_post_content' ), $forms );
 		}
-
-		wp_cache_set( $cache_key, $forms, 'form_get_multiple_results' );
 
 		return $forms;
 	}

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -528,7 +528,7 @@ class EVF_Form_Task {
 		if ( ! empty( $submission_redirect_process ) ) {
 			$settings['redirect_to']  = $submission_redirect_process['redirect_to'];
 			$settings['external_url'] = $submission_redirect_process['external_url'];
-			$settings['custom_page'] = $submission_redirect_process['custom_page'];
+			$settings['custom_page']  = $submission_redirect_process['custom_page'];
 		}
 
 		if ( isset( $settings['redirect_to'] ) && 'custom_page' === $settings['redirect_to'] ) {
@@ -799,6 +799,14 @@ class EVF_Form_Task {
 		}
 
 		$this->entry_id = $entry_id;
+
+		// Removing Entries Cache.
+		wp_cache_delete( $entry_id, 'evf-entry' );
+		wp_cache_delete( $entry_id, 'evf-entrymeta' );
+		wp_cache_delete( $form_id, 'evf-entries-ids' );
+		wp_cache_delete( $form_id, 'evf-last-entries-count' );
+		wp_cache_delete( $form_id, 'evf-search-entries' );
+		wp_cache_delete( EVF_Cache_Helper::get_cache_prefix( 'entries' ) . '_unread_count', 'entries' );
 
 		do_action( 'everest_forms_complete_entry_save', $entry_id, $fields, $entry, $form_id, $form_data );
 

--- a/includes/evf-entry-functions.php
+++ b/includes/evf-entry-functions.php
@@ -173,14 +173,6 @@ function evf_search_entries( $args ) {
 	$where     = (array) apply_filters( 'everest_forms_search_entries_where', $where, $args );
 	$where_sql = implode( ' AND ', $where );
 
-	// Check for cache.
-	$cache_key   = EVF_Cache_Helper::get_cache_prefix( 'entries' ) . 'search_entries' . md5( wp_json_encode( $args ) );
-	$cache_value = wp_cache_get( $cache_key, 'entry_search_results' );
-
-	if ( $cache_value ) {
-		return $cache_value;
-	}
-
 	// Query object.
 	$query   = array();
 	$query[] = "SELECT DISTINCT {$wpdb->prefix}evf_entries.entry_id FROM {$wpdb->prefix}evf_entries INNER JOIN {$wpdb->prefix}evf_entrymeta WHERE {$where_sql}";
@@ -227,8 +219,6 @@ function evf_search_entries( $args ) {
 
 	$ids = wp_list_pluck( $results, 'entry_id' );
 
-	wp_cache_set( $cache_key, $ids, 'entry_search_results' );
-
 	return $ids;
 }
 
@@ -244,22 +234,15 @@ function evf_get_count_entries_by_status( $form_id ) {
 	$counts    = array();
 
 	foreach ( $statuses as $status ) {
-		$cache_key = EVF_Cache_Helper::get_cache_prefix( 'entries' ) . $status . '_count';
-		$count     = wp_cache_get( $cache_key, 'entries' );
-
-		if ( false === $count ) {
-			$count = count(
-				evf_search_entries(
-					array(
-						'limit'   => -1,
-						'status'  => $status,
-						'form_id' => $form_id,
-					)
+		$count = count(
+			evf_search_entries(
+				array(
+					'limit'   => -1,
+					'status'  => $status,
+					'form_id' => $form_id,
 				)
-			);
-
-			wp_cache_add( $cache_key, $count, 'entries' );
-		}
+			)
+		);
 
 		$counts[ $status ] = $count;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR Fixed the Caching issue in forms and entries. Initially form was not saved from the builder due to object caching. 

### How to test the changes in this Pull Request:

1. Download and Install Redis server in your machine.
2. Install Redis Object Caching Plugin in WordPress.
3. Enable Object Caching form setting of Redis.
4. Create Forms and Submit Entries.
5. Verify it works as expected.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Everest forms caching issue in Forms and Entries.
