### PR TITLE
EVF-242 Feature - Populate form field via query string 

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -821,6 +821,19 @@
 				}
 			});
 
+			$builder.on( 'change', '.everest-forms-field-option-row-enable_prepopulate input', function( event ) {
+				var id = $( this ).parent().data( 'field-id' );
+
+				$( '#everest-forms-field-' + id ).toggleClass( 'parameter_name' );
+
+				// Toggle "Parameter Name" option.
+				if ( $( event.target ).is( ':checked' ) ) {
+					$( '#everest-forms-field-option-row-' + id + '-parameter_name' ).show();
+				} else {
+					$( '#everest-forms-field-option-row-' + id + '-parameter_name' ).hide();
+				}
+			});
+
 			// Real-time updates for "Description" field option.
 			$builder.on( 'input', '.everest-forms-field-option-row-description textarea', function() {
 				var $this = $( this ),

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1178,6 +1178,68 @@ abstract class EVF_Form_Fields {
 					false
 				);
 				break;
+			case 'enable_prepopulate':
+				$default = ! empty( $args['default'] ) ? $args['default'] : '0';
+				$value   = ! empty( $field['enable_prepopulate'] ) ? esc_attr( $field['enable_prepopulate'] ) : '';
+				$tooltip = esc_html__( 'Enable this option to allow field to be populated dynamically', 'everest-forms' );
+				$output  = $this->field_element(
+					'checkbox',
+					$field,
+					array(
+						'slug'    => 'enable_prepopulate',
+						'value'   => $value,
+						'desc'    => esc_html__( 'Enable Autopoupulate ', 'everest-forms' ),
+						'tooltip' => $tooltip,
+					),
+					false
+				);
+				$output  = $this->field_element(
+					'row',
+					$field,
+					array(
+						'slug'    => 'enable_prepopulate',
+						'content' => $output,
+					),
+					false
+				);
+				break;
+			case 'parameter_name':
+					$toggle  = '';
+					$tooltip = esc_html__( 'Enter name of the parameter to populate the field.', 'everest-forms' );
+					$value   = ! empty( $field['parameter_name'] ) ? esc_attr( $field['parameter_name'] ) : '';
+
+					// Build output.
+					$output  = $this->field_element(
+						'label',
+						$field,
+						array(
+							'slug'          => 'parameter_name',
+							'value'         => esc_html__( 'Parameter Name', 'everest-forms' ),
+							'tooltip'       => $tooltip,
+							'after_tooltip' => $toggle,
+						),
+						false
+					);
+					$output .= $this->field_element(
+						'text',
+						$field,
+						array(
+							'slug'  => 'parameter_name',
+							'value' => $value,
+						),
+						false
+					);
+					$output  = $this->field_element(
+						'row',
+						$field,
+						array(
+							'slug'    => 'parameter_name',
+							'content' => $output,
+							'class'   => isset( $field['parameter_name'] ) ? '' : 'hidden',
+						),
+						false
+					);
+				break;
 
 			/*
 			 * CSS classes.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR  gives the users to autopopulate the form through query string .


### How to test the changes in this Pull Request:
Test This [PR](https://github.com/wpeverest/everest-forms-pro/pull/438)

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - Populate form field via query string.