### PR TITLE
EVF-249 Fix - Ajax form submission issue

### DIFF
--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -69,6 +69,7 @@ jQuery( function( $ ) {
 								error   =  everest_forms_ajax_submission_params.error,
 								err     =  JSON.parse( errorThrown.responseText ),
 								fields  = err.data.error;
+								error =  err.data[form_id].header
 
 								if ( 'string' === typeof err.data.message ) {
 									error =  err.data.message;

--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -66,10 +66,9 @@ jQuery( function( $ ) {
 							localStorage.removeItem(formTuple.attr('id'));
 						} else {
 							var	form_id = formTuple.data( 'formid' ),
-								error   =  everest_forms_ajax_submission_params.error,
 								err     =  JSON.parse( errorThrown.responseText ),
+								error =  err.data[form_id].header,
 								fields  = err.data.error;
-								error =  err.data[form_id].header
 
 								if ( 'string' === typeof err.data.message ) {
 									error =  err.data.message;

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -93,6 +93,7 @@ class EVF_Form_Task {
 			$response_data          = array();
 			$this->ajax_err         = array();
 			$this->evf_notice_print = false;
+			$logger                 = evf_get_logger();
 
 			// Check nonce for form submission.
 			if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), 'everest-forms_process_submit' ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -270,11 +271,13 @@ class EVF_Form_Task {
 			// because at this point we have completed all field validation and
 			// formatted the data.
 			$this->form_fields = apply_filters( 'everest_forms_process_filter', $this->form_fields, $entry, $this->form_data );
+			$logger->notice( sprintf( 'Everest Form Process: %s', evf_print_r( $this->form_fields, true ) ) );
 
 			do_action( 'everest_forms_process', $this->form_fields, $entry, $this->form_data );
 			do_action( "everest_forms_process_{$form_id}", $this->form_fields, $entry, $this->form_data );
 
 			$this->form_fields = apply_filters( 'everest_forms_process_after_filter', $this->form_fields, $entry, $this->form_data );
+			$logger->notice( sprintf( 'Everest Form Process After: %s', evf_print_r( $this->form_fields, true ) ) );
 
 			// One last error check - don't proceed if there are any errors.
 			if ( ! empty( $this->errors[ $form_id ] ) ) {
@@ -284,11 +287,15 @@ class EVF_Form_Task {
 				return $this->errors;
 			}
 
+			$logger->notice( sprintf( 'Entry is Saving to DataBase' ) );
 			// Success - add entry to database.
 			$entry_id = $this->entry_save( $this->form_fields, $entry, $this->form_data['id'], $this->form_data );
+			$logger->notice( sprintf( 'Entry is Saved to DataBase' ) );
 
+			$logger->notice( sprintf( 'Sending Email' ) );
 			// Success - send email notification.
 			$this->entry_email( $this->form_fields, $entry, $this->form_data, $entry_id, 'entry' );
+			$logger->notice( sprintf( 'Successfully Send the email' ) );
 
 			// @todo remove this way of printing notices.
 			add_filter( 'everest_forms_success', array( $this, 'check_success_message' ), 10, 2 );

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -307,7 +307,7 @@ class EVF_Frontend_Scripts {
 					'ajax_url'            => admin_url( 'admin-ajax.php' ),
 					'evf_ajax_submission' => wp_create_nonce( 'everest_forms_ajax_form_submission' ),
 					'submit'              => esc_html__( 'Submit', 'everest-forms' ),
-					'error'               => esc_html__( 'Sorry, something went wrong. Please try again', 'everest-forms' ),
+					'error'               => esc_html__( 'Something went wrong while making an AJAX submission', 'everest-forms' ),
 					'required'            => esc_html__( 'This field is required.', 'everest-forms' ),
 					'pdf_download'        => esc_html__( 'Click here to download your pdf submission', 'everest-forms' ),
 				);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, when the ajax enabled and when we try to submit the form if the form failed to submit it throws something went wrong message. 


### How to test the changes in this Pull Request:

1. Go to the form builder > Setting > General > Enable ajax submission
2. Try to submit the form with error.
3. Verify whether the correct error message is displaying or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Ajax form submission issue
