### PR TITLE
Fix: Check for WP_Error `in evf_get_allowed_html_tags`

### DIFF
--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -2387,7 +2387,8 @@ function evf_get_allowed_html_tags( $context = '' ) {
 	$post_tags = wp_kses_allowed_html( 'post' );
 	if ( 'builder' === $context ) {
 		$response = wp_safe_remote_get( evf()->plugin_url() . '/assets/allowed_tags/allowed_tags.json' );
-		if ( $response && 200 === $response['response']['code'] ) {
+		
+		if ( ! is_wp_error( $response ) ) {
 			$json = wp_remote_retrieve_body( $response );
 			if ( ! empty( $json ) ) {
 				$allowed_tags = json_decode( $json, true );

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -2387,7 +2387,7 @@ function evf_get_allowed_html_tags( $context = '' ) {
 	$post_tags = wp_kses_allowed_html( 'post' );
 	if ( 'builder' === $context ) {
 		$response = wp_safe_remote_get( evf()->plugin_url() . '/assets/allowed_tags/allowed_tags.json' );
-		
+
 		if ( ! is_wp_error( $response ) ) {
 			$json = wp_remote_retrieve_body( $response );
 			if ( ! empty( $json ) ) {


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `wp_safe_remote_get` function returns an `array|WP_Error`. In the previous check, it was too optimistic which was causing errors on a few of the websites I manage (which I haven't dug into why this was even failing in the first place). The error was `Uncaught Error: Cannot use object of type WP_Error as array` due to the check of the status code. Performing the `is_wp_error` alleviates this, as anything other than an `WP_Error` is a success in this context anyway.

### Types of changes:

* [ x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Replace status code check with is_wp_error in `evf_get_allowed_html_tags`
