### PR TITLE
Fix - reCAPTCHA v3 threshold display issue.

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -95,6 +95,7 @@
 			recaptcha_v2_invisible            = $( '#everest_forms_recaptcha_v2_invisible' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v3_site_key             = $( '#everest_forms_recaptcha_v3_site_key' ).parents( 'tr' ).eq( 0 ),
 			recaptcha_v3_secret_key           = $( '#everest_forms_recaptcha_v3_secret_key' ).parents( 'tr' ).eq( 0 );
+			recaptcha_v3_threshold_score      = $( '#everest_forms_recaptcha_v3_threshold_score' ).parents( 'tr' ).eq( 0 );
 			hcaptcha_site_key            	  = $( '#everest_forms_recaptcha_hcaptcha_site_key' ).parents( 'tr' ).eq( 0 ),
 			hcaptcha_secret_key               = $( '#everest_forms_recaptcha_hcaptcha_secret_key' ).parents( 'tr' ).eq( 0 );
 
@@ -124,6 +125,7 @@
 				recaptcha_v2_invisible_secret_key.hide();
 				recaptcha_v3_site_key.hide();
 				recaptcha_v3_secret_key.hide();
+				recaptcha_v3_threshold_score.hide();
 				recaptcha_v2_site_key.hide();
 				recaptcha_v2_secret_key.hide();
 				hcaptcha_site_key.show();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.8.5 - xx-xx-2022 =
+Fix - reCAPTCHA v3 threshold display glitch.
+
 = 1.8.4 - 03-02-2022 =
 * Fix - Attribute issue in multipart.
 * Fix - Date Time $ missing form variable name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?



### Changes proposed in this Pull Request:

Previously, 'Threshold Score'  wasn't hiding for  reCAPTCHA v2 and hCaptcha. This PR hides 'Threshold Score' for reCAPTCHA v2 and hCaptcha.


### How to test the changes in this Pull Request:

1. Verify, 'Threshold Score' is hiding or not for reCAPTCHA v2 and hCaptcha.


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Enhancement - reCAPTCHA.
