### PR TITLE
Fix - Preview issue in twenty twenty two theme

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.8.5 - xx-xx-2022 =
+* Fix - Preview issue in twenty twenty two theme.
+
 = 1.8.4 - 03-02-2022 =
 * Fix - Attribute issue in multipart.
 * Fix - Date Time $ missing form variable name.

--- a/includes/class-evf-template-loader.php
+++ b/includes/class-evf-template-loader.php
@@ -36,7 +36,8 @@ class EVF_Template_Loader {
 		if ( ! is_admin() && isset( $_GET['evf_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			add_action( 'pre_get_posts', array( __CLASS__, 'pre_get_posts' ) );
 			add_filter( 'edit_post_link', array( __CLASS__, 'edit_form_link' ) );
-			add_filter( 'template_include', array( __CLASS__, 'template_include' ) );
+			add_filter( 'home_template_hierarchy', array( __CLASS__, 'template_include' ) );
+			add_filter( 'frontpage_template_hierarchy', array( __CLASS__, 'template_include' ) );
 			add_action( 'template_redirect', array( __CLASS__, 'form_preview_init' ) );
 		} else {
 			add_filter( 'template_include', array( __CLASS__, 'template_loader' ) );
@@ -73,8 +74,8 @@ class EVF_Template_Loader {
 	 *
 	 * @return string
 	 */
-	public static function template_include() {
-		return locate_template( array( 'page.php', 'single.php', 'index.php' ) );
+	public static function template_include( $templates ) {
+		return array( 'page.php', 'single.php', 'index.php' );
 	}
 
 	/**

--- a/includes/class-evf-template-loader.php
+++ b/includes/class-evf-template-loader.php
@@ -70,9 +70,11 @@ class EVF_Template_Loader {
 	}
 
 	/**
-	 * Limit page templates to singular pages only.
+	 *  A list of template candidates.
 	 *
-	 * @return string
+	 * @param array $templates A list of template candidates, in descending order of priority.
+	 *
+	 * @return array
 	 */
 	public static function template_include( $templates ) {
 		return array( 'page.php', 'single.php', 'index.php' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously when we Switch twenty twenty two theme form preview is showing blank. This Pr solve this issue.

### How to test the changes in this Pull Request:

1. Activate Twenty Twenty Two Theme.
2. Create the form and Preview the form.
3. verify form is showing or not and change to other theme also it is working or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Preview issue in twenty twenty two theme.
