### PR TITLE
Fix - Select2-conflict with job manager plugin

### DIFF
--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -206,7 +206,7 @@ class EVF_Frontend_Scripts {
 	 */
 	private static function register_styles() {
 		$register_styles = array(
-			'select2'   => array(
+			'evf_select2'   => array(
 				'src'     => self::get_asset_url( 'assets/css/select2.css' ),
 				'deps'    => array(),
 				'version' => EVF_VERSION,

--- a/includes/fields/class-evf-field-select.php
+++ b/includes/fields/class-evf-field-select.php
@@ -160,7 +160,7 @@ class EVF_Field_Select extends EVF_Form_Fields {
 			);
 
 			if ( ! empty( $is_enhanced_select ) ) {
-				wp_enqueue_style( 'select2' );
+				wp_enqueue_style( 'evf_select2' );
 				wp_enqueue_script( 'selectWoo' );
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR resolves select2 conflict with Booking Manager plugin. Ref [PR](https://github.com/wpeverest/everest-forms-pro/pull/513)

### How to test the changes in this Pull Request:

1. Install WP Job Manager
2. Create form with select 2
3. Verify its working as expected

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Select2-conflict with job manager plugin
