### PR TITLE
Fix - Meta Key Translation issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 == Changelog ==
 
 = 1.8.6 - 29-03-2022 =
+* Fix - Meta Key Translation issue.
+
+= 1.8.6 - 29-03-2022 =
 * Tweak - CAPTCHA text change.
 * Enhancement - CAPTCHA language.
 * Enhancement - Select/Unselect All options in checkboxes field.

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1169,8 +1169,7 @@ function evf_get_all_forms( $skip_disabled_entries = false ) {
  * @return string
  */
 function evf_get_meta_key_field_option( $field ) {
-	$random_number = rand( pow( 10, 3 ), pow( 10, 4 ) - 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-	return strtolower( str_replace( array( ' ', '/_' ), array( '_', '' ), $field['label'] ) ) . '_' . $random_number;
+	return preg_replace( '/[^a-zA-Z0-9\s`_]/', '', $field['label'] ) . '_' . rand( pow( 10, 3 ), pow( 10, 4 ) - 1 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When the user change the site language the meta_key also being translated automatically.

### How to test the changes in this Pull Request:

1. Install new setup of WordPress.
2. Change the Site Language from WordPress General Setting.
3.  Create a form and verify if the field is dragged meta_key is also changed site language or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Meta Key Translation issue.
