### PR TITLE
Fix - Auto address field value not rendering issue in style

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.9.2 - xx-xx-2022
 * Fix - Flatpickr localization issue.
+* Fix - Auto address selected value not rendering issue in style dropdown after change.
 
 = 1.9.1 - 19-07-2022
 * Fix - Enhanced select issue in single select.

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -908,6 +908,7 @@ abstract class EVF_Form_Fields {
 			case 'address_style':
 				$default = ! empty( $args['default'] ) ? $args['default'] : 'none';
 				$tooltip = esc_html__( 'Select the style', 'everest-forms' );
+				$value   = ! empty( $field['address_style'] ) ? esc_attr( $field['address_style'] ) : '';
 				$output  = $this->field_element(
 					'label',
 					$field,
@@ -923,7 +924,7 @@ abstract class EVF_Form_Fields {
 					$field,
 					array(
 						'slug'    => 'address_style',
-						'value'   => esc_html__( 'style', 'everest-forms' ),
+						'value'   => $value,
 						'tooltip' => $tooltip,
 						'options' => array(
 							'address'          => esc_html__( 'Address', 'everest-forms' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When  the Auto Address field changes by default to ‘Address' rather that others options.

### How to test the changes in this Pull Request:

1. Create a form.
2. Activate geolocation addon and drag and drop address field.
3. verify if the selected value of style is rendered correctly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Auto address field value not rendering issue in style.
