### PR TITLE
Fix - Flatpickr date localization not working while the form has more than date one field.

### DIFF
--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -92,8 +92,8 @@ jQuery( function ( $ ) {
 		},
 		init_datepicker: function () {
 			var evfDateField = $( '.evf-field-date-time' );
-			if ( evfDateField.length > 0 ) {
-				$( '.flatpickr-field' ).each( function() {
+			if ( evfDateField.length && evfDateField.find( '.flatpickr-field' ).length ) {
+				evfDateField.find( '.flatpickr-field' ).each( function () {
 					var timeInterval = 5,
 						inputData  	 = $( this ).data(),
 						disableDates = [];
@@ -157,7 +157,7 @@ jQuery( function ( $ ) {
 						break;
 						default:
 					}
-				});
+				} );
 			}
 		},
 		init_datedropdown: function () {

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.9.6 - xx-xx-2022
 * Enhancement - Entry ID smart tag in the email message.
+* Fix - Flatpickr date localization not working while the form has more than date one field.
 
 = 1.9.5 - 18-10-2022
 * Enhancement - Form ID smart tag.​

--- a/includes/fields/class-evf-field-date-time.php
+++ b/includes/fields/class-evf-field-date-time.php
@@ -783,18 +783,26 @@ class EVF_Field_Date_Time extends EVF_Form_Fields {
 		$form_id   = isset( $atts['id'] ) ? wp_unslash( $atts['id'] ) : ''; // WPCS: CSRF ok, input var ok, sanitization ok.
 		$form_obj  = evf()->form->get( $form_id );
 		$form_data = ! empty( $form_obj->post_content ) ? evf_decode( $form_obj->post_content ) : '';
-		$data_i10n = 'en';
 
 		if ( ! empty( $form_data['form_fields'] ) ) {
+			$data_i10ns = array();
 			foreach ( $form_data['form_fields'] as $form_field ) {
-				if ( 'date-time' === $form_field['type'] ) {
+				if ( 'date-time' === $form_field['type'] && 'picker' === $form_field['datetime_style'] ) {
 					$data_i10n = isset( $form_field['date_localization'] ) ? $form_field['date_localization'] : 'en';
+
+					if ( ! in_array( $data_i10n, $data_i10ns, true ) && 'en' !== $data_i10n ) {
+						$data_i10ns[] = $data_i10n;
+					}
 				}
 			}
-		}
 
-		if ( wp_script_is( 'flatpickr' ) && 'en' !== $data_i10n && 'picker' === $form_field['datetime_style'] ) {
-			wp_enqueue_script( 'flatpickr-localization', evf()->plugin_url() . '/assets/js/flatpickr/dist/I10n/' . $data_i10n . '.js', array(), EVF_VERSION, true );
+			if ( ! empty( $data_i10ns ) ) {
+				foreach ( $data_i10ns as $data_i10n ) {
+					if ( wp_script_is( 'flatpickr' ) ) {
+						wp_enqueue_script( 'flatpickr-localization-' . $data_i10n, evf()->plugin_url() . '/assets/js/flatpickr/dist/I10n/' . $data_i10n . '.js', array(), EVF_VERSION, true );
+					}
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

if the form has another date field with enabling date localization, date localization feature is not working. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Verify, Date location feature is working or not while the form has more than one field.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Flatpickr date localization not working while the form has more than date one field.
