### PR TITLE
Fix - Stripe issue with credit card field empty.

### DIFF
--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -16,6 +16,11 @@ jQuery( function( $ ) {
 						paymentMethod = formTuple.find( ".everest-forms-gateway[data-gateway='stripe']" ).data( 'gateway' );
 					}
 
+					if (formTuple.find( ".everest-forms-gateway[data-gateway='stripe']").hasClass('StripeElement--empty') && $(".evf-field-credit-card ").is(':visible') ){
+						$( '#card-errors' ).html( 'This field is required' ).show();
+						return false;
+					}
+
 					if ( typeof tinyMCE !== 'undefined' ) {
 						tinyMCE.triggerSave();
 					}

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - 1.9.8       - xx-xx-2022
 * Enhancement - CSV export for repeater field.
+* Fix - Stripe issue with credit card field empty.
 
 = 1.9.7       - 21-12-2022
 * Fix         - Empty for zero value in the number field.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:
Previously, When the credit field is empty and the form is submitting without entering details. This PR fixes this issue

### How to test the changes in this Pull Request:

1. Create a form.
2. Enable stripe and Submit the form without entering credit card details.
3. Verify whether it is working or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Stripe issue with credit card field empty.
