### PR TITLE
Feature - Allow usage tracking notice.

### DIFF
--- a/assets/css/activation.scss
+++ b/assets/css/activation.scss
@@ -118,6 +118,57 @@ div.everest-forms-message {
 		}
 	}
 
+	&.evf-allow-usage-notice {
+		padding: 16px;
+		display: flex;
+		align-items: center;
+
+		.everest-forms-logo {
+			height: 120px;
+			width: 120px;
+			border-radius: 4px;
+			margin-right: 20px;
+			flex: 0 0 120px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			background: $everestforms;
+
+			svg {
+				height: 80px;
+				width: 80px;
+				fill: $color-white;
+			}
+		}
+
+		.everest-forms-message--content {
+			h3 {
+				margin: 0;
+				font-size: 20px;
+				line-height: 1.5;
+			}
+
+			p {
+				margin-top: 4px;
+				padding: 0;
+
+				&.submit {
+					margin-top: 9px;
+					margin-bottom: 0;
+
+					.button {
+						margin-right: 5px;
+					}
+
+					.evf-button-link {
+						padding: 0 2px 0;
+						box-shadow: none;
+					}
+				}
+			}
+		}
+	}
+
 	a.everest-forms-message-close {
 		position: static;
 		float: right;

--- a/includes/admin/class-evf-admin-notices.php
+++ b/includes/admin/class-evf-admin-notices.php
@@ -26,9 +26,10 @@ class EVF_Admin_Notices {
 	 * @var array
 	 */
 	private static $core_notices = array(
-		'update' => 'update_notice',
-		'review' => 'review_notice',
-		'survey' => 'survey_notice',
+		'update'      => 'update_notice',
+		'review'      => 'review_notice',
+		'survey'      => 'survey_notice',
+		'allow_usage' => 'allow_usage_notice',
 	);
 
 	/**
@@ -80,6 +81,7 @@ class EVF_Admin_Notices {
 		}
 		self::add_notice( 'review' );
 		self::add_notice( 'survey' );
+		self::add_notice( 'allow_usage' );
 	}
 
 	/**
@@ -297,6 +299,25 @@ class EVF_Admin_Notices {
 
 		return $status;
 
+	}
+
+	/**
+	 * Include allow usage & discount notice.
+	 */
+	public static function allow_usage_notice() {
+
+		$show_notice              = true;
+		$allow_usage_notice_shown = get_option( 'everest_forms_allow_usage_notice_shown', false );
+		$allow_usage_tracking     = get_option( 'everest_forms_allow_usage_tracking' );
+		$activated                = get_option( 'everest_forms_activated' );
+
+		if ( 'yes' === $allow_usage_tracking || ( $activated + DAY_IN_SECONDS > time() ) || $allow_usage_notice_shown ) {
+			$show_notice = false;
+		}
+
+		if ( $show_notice && ( is_super_admin() || current_user_can( 'manage_everest_forms' ) ) ) {
+			include 'views/html-notice-allow-usage.php';
+		}
 	}
 
 	/**

--- a/includes/admin/settings/class-evf-settings-misc.php
+++ b/includes/admin/settings/class-evf-settings-misc.php
@@ -33,10 +33,26 @@ class EVF_Settings_Misc extends EVF_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings() {
-		$allow_usage_notice_msg = esc_html__( 'Get improved features by sharing non-sensitive plugin data and receive occasional email updates. Get a discount code emailed immediately.', 'everest-forms' );
+		$allow_usage_notice_msg = wp_kses(
+			__( ' Help us improve the plugin\'s features and receive an instant discount coupon with occasional email updates by sharing <a href="https://docs.wpeverest.com/everest-forms/docs/misc-settings/#2-toc-title" target="_blank">non-sensitive plugin data</a> with us.', 'everest-forms' ),
+			array(
+				'a' => array(
+					'href'   => array(),
+					'target' => array()
+				)
+			)
+		);
 
 		if ( false !== evf_get_license_plan() ) {
-			$allow_usage_notice_msg = esc_html__( 'Get improved features by sharing non-sensitive plugin data.', 'everest-forms' );
+			$allow_usage_notice_msg = wp_kses(
+				__( 'Help us improve the plugin\'s features by sharing <a href="https://docs.wpeverest.com/everest-forms/docs/misc-settings/#2-toc-title" target="_blank">non-sensitive plugin data</a> with us.', 'everest-forms' ),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array()
+					)
+				)
+			);
 		}
 
 		$settings = apply_filters(

--- a/includes/admin/settings/class-evf-settings-misc.php
+++ b/includes/admin/settings/class-evf-settings-misc.php
@@ -33,6 +33,12 @@ class EVF_Settings_Misc extends EVF_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings() {
+		$allow_usage_notice_msg = esc_html__( 'Get improved features by sharing non-sensitive plugin data and receive occasional email updates. Get a discount code emailed immediately.', 'everest-forms' );
+
+		if ( false !== evf_get_license_plan() ) {
+			$allow_usage_notice_msg = esc_html__( 'Get improved features by sharing non-sensitive plugin data.', 'everest-forms' );
+		}
+
 		$settings = apply_filters(
 			'everest_forms_misc_settings',
 			array(
@@ -51,7 +57,7 @@ class EVF_Settings_Misc extends EVF_Settings_Page {
 				),
 				array(
 					'title'   => esc_html__( 'Allow Usage Tracking', 'everest-forms' ),
-					'desc'    => esc_html__( 'Get improved features by sharing non-sensitive plugin data and receive occasional email updates. Get a discount code emailed immediately.', 'everest-forms' ),
+					'desc'    => $allow_usage_notice_msg,
 					'id'      => 'everest_forms_allow_usage_tracking',
 					'type'    => 'checkbox',
 					'default' => 'no',

--- a/includes/admin/views/html-notice-allow-usage.php
+++ b/includes/admin/views/html-notice-allow-usage.php
@@ -13,9 +13,25 @@ defined( 'ABSPATH' ) || exit;
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.15,4l1.23,2H15.49L14.26,4ZM20,20H2.21L12,4.09,18.1,14H10.77L12,12h2.52L12,7.91,5.79,18H20.56l1.23,2ZM17.94,10,16.71,8H20.6l1.23,2Z"/></svg>
 	</div>
 	<div class="everest-forms-message--content">
-		<h3 class="everest-forms-message__title"><?php esc_html_e( 'Unlock Features & Discount', 'everest-forms' ); ?></h3>
+		<h3 class="everest-forms-message__title">
+		<?php
+		if ( false !== evf_get_license_plan() ) {
+			esc_html_e( 'Unlock Features', 'everest-forms' );
+		} else {
+			esc_html_e( 'Unlock Features & Discount', 'everest-forms' );
+		}
+		?>
+		</h3>
 		<p class="everest-forms-message__description">
 			<?php
+			if ( false !== evf_get_license_plan() ) {
+				printf(
+					esc_html__(
+						'Get improved features by sharing non-sensitive plugin data by allowing.',
+						'everest-forms'
+					)
+				);
+			} else {
 				printf(
 					esc_html__(
 						'Get improved features by sharing non-sensitive plugin data and receiving occasional email updates. 
@@ -23,11 +39,12 @@ defined( 'ABSPATH' ) || exit;
 						'everest-forms'
 					)
 				);
-				?>
+			}
+			?>
 		</p>
 		<p class="everest-forms-message__action submit">
 			<a href="#" class="button button-primary evf-dismiss-allow-usage-notice evf-allow-data-sharing" target="_blank" rel="noopener noreferrer"><span  class="dashicons dashicons-smiley"></span><?php esc_html_e( 'Allow', 'everest-forms' ); ?></a>
-			<a href="#" class="button button-secondary evf-dismiss-allow-usage-notice evf-deny-data-sharing" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-dismiss"></span><?php esc_html_e( 'Deny', 'everest-forms' ); ?></a>
+			<a href="#" class="button button-secondary evf-dismiss-allow-usage-notice evf-deny-data-sharing" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-dismiss"></span><?php esc_html_e( 'No, Thanks', 'everest-forms' ); ?></a>
 		</p>
 	</div>
 </div>

--- a/includes/admin/views/html-notice-allow-usage.php
+++ b/includes/admin/views/html-notice-allow-usage.php
@@ -14,29 +14,32 @@ defined( 'ABSPATH' ) || exit;
 	</div>
 	<div class="everest-forms-message--content">
 		<h3 class="everest-forms-message__title">
-		<?php
-		if ( false !== evf_get_license_plan() ) {
-			esc_html_e( 'Unlock Features', 'everest-forms' );
-		} else {
-			esc_html_e( 'Unlock Features & Discount', 'everest-forms' );
-		}
-		?>
+		<?php esc_html_e( 'Contribute to the enhancement', 'everest-forms' ); ?>
 		</h3>
 		<p class="everest-forms-message__description">
 			<?php
 			if ( false !== evf_get_license_plan() ) {
 				printf(
-					esc_html__(
-						'Get improved features by sharing non-sensitive plugin data by allowing.',
-						'everest-forms'
+					wp_kses(
+						__( 'Help us improve the plugin\'s features by sharing <a href="https://docs.wpeverest.com/everest-forms/docs/misc-settings/#2-toc-title" target="_blank">non-sensitive plugin data</a> with us.', 'everest-forms' ),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array()
+							)
+						)
 					)
 				);
 			} else {
 				printf(
-					esc_html__(
-						'Get improved features by sharing non-sensitive plugin data and receiving occasional email updates. 
-						By allowing, you will receive a discount code via email immediately.',
-						'everest-forms'
+					wp_kses(
+						__( ' Help us improve the plugin\'s features and receive an instant discount coupon with occasional email updates by sharing <a href="https://docs.wpeverest.com/everest-forms/docs/misc-settings/#2-toc-title" target="_blank">non-sensitive plugin data</a> with us.', 'everest-forms' ),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array()
+							)
+						)
 					)
 				);
 			}

--- a/includes/admin/views/html-notice-allow-usage.php
+++ b/includes/admin/views/html-notice-allow-usage.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Admin View: Notice - Allow Usage
+ *
+ * @package EverestForms\Admin\Notice
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="message" class="updated everest-forms-message evf-allow-usage-notice">
+	<div class="everest-forms-logo">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18.15,4l1.23,2H15.49L14.26,4ZM20,20H2.21L12,4.09,18.1,14H10.77L12,12h2.52L12,7.91,5.79,18H20.56l1.23,2ZM17.94,10,16.71,8H20.6l1.23,2Z"/></svg>
+	</div>
+	<div class="everest-forms-message--content">
+		<h3 class="everest-forms-message__title"><?php esc_html_e( 'Unlock Features & Discount', 'everest-forms' ); ?></h3>
+		<p class="everest-forms-message__description">
+			<?php
+				printf(
+					esc_html__(
+						'Get improved features by sharing non-sensitive plugin data and receiving occasional email updates. 
+						By allowing, you will receive a discount code via email immediately.',
+						'everest-forms'
+					)
+				);
+				?>
+		</p>
+		<p class="everest-forms-message__action submit">
+			<a href="#" class="button button-primary evf-dismiss-allow-usage-notice evf-allow-data-sharing" target="_blank" rel="noopener noreferrer"><span  class="dashicons dashicons-smiley"></span><?php esc_html_e( 'Allow', 'everest-forms' ); ?></a>
+			<a href="#" class="button button-secondary evf-dismiss-allow-usage-notice evf-deny-data-sharing" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-dismiss"></span><?php esc_html_e( 'Deny', 'everest-forms' ); ?></a>
+		</p>
+	</div>
+</div>
+<script type="text/javascript">
+	jQuery( document ).ready( function ( $ ) {
+		$( document ).on( 'click', '.evf-dismiss-allow-usage-notice', function ( event ) {
+			event.preventDefault();
+			var allow_usage_tracking = false;
+
+			if( $(this).hasClass('evf-allow-data-sharing') ) {
+				allow_usage_tracking = true;
+			}
+
+			$.post( ajaxurl, {
+				action: 'everest_forms_allow_usage_dismiss',
+				allow_usage_tracking: allow_usage_tracking,
+				_wpnonce: '<?php echo esc_js( wp_create_nonce( 'allow_usage_nonce' ) ); ?>'
+			} );
+			$( '.evf-allow-usage-notice' ).remove();
+		} );
+	} );
+</script>

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -92,6 +92,7 @@ class EVF_AJAX {
 			'rated'                   => false,
 			'review_dismiss'          => false,
 			'survey_dismiss'          => false,
+			'allow_usage_dismiss'     => false,
 			'enabled_form'            => false,
 			'import_form_action'      => false,
 			'template_licence_check'  => false,
@@ -718,6 +719,27 @@ class EVF_AJAX {
 		$survey              = get_option( 'everest_forms_survey', array() );
 		$survey['dismissed'] = true;
 		update_option( 'everest_forms_survey', $survey );
+		wp_die();
+	}
+
+	/**
+	 * Triggered when clicking the allow usage notice allow or deny buttons.
+	 */
+	public static function allow_usage_dismiss() {
+		check_ajax_referer( 'allow_usage_nonce', '_wpnonce' );
+
+		if ( ! current_user_can( 'manage_everest_forms' ) ) {
+			wp_die( -1 );
+		}
+
+		$allow_usage_tracking = isset( $_POST['allow_usage_tracking'] ) ? sanitize_text_field( wp_unslash( $_POST['allow_usage_tracking'] ) ) : false;
+
+		update_option( 'everest_forms_allow_usage_notice_shown', true );
+
+		if ( 'true' === $allow_usage_tracking ) {
+			update_option( 'everest_forms_allow_usage_tracking', 'yes' );
+		}
+
 		wp_die();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces a notice for allow usage tracking feature. The notice will be shown after at least one day after activation.

### How to test the changes in this Pull Request:

1. Verify whether the notice is showing or not  if the plugin activation period is  at least one day.


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - Allow usage tracking notice.
