### PR TITLE
Fix - Send Test Email To option does not display the value saved value in the DB

### DIFF
--- a/includes/admin/settings/class-evf-settings-email.php
+++ b/includes/admin/settings/class-evf-settings-email.php
@@ -73,7 +73,7 @@ class EVF_Settings_Email extends EVF_Settings_Page {
 					'id'          => 'everest_forms_email_send_to',
 					'type'        => 'email',
 					'placeholder' => 'eg. testemail@gmail.com',
-					'value'       => esc_attr( get_bloginfo( 'admin_email' ) ),
+					'value'       => get_option( 'everest_forms_email_send_to', '' ) ? esc_attr( get_option( 'everest_forms_email_send_to', '' ) ) : esc_attr( get_bloginfo( 'admin_email' ) ),
 					'desc_tip'    => true,
 				),
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, in the Sent Test Email feature, Send Test Email To option always display admin regardless of DB saved value.

### How to test the changes in this Pull Request:

1. Verify, whether the above-mentioned issue is fixed or not.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Send Test Email To option does not display the value saved value in the DB.
