### PR TITLE
Fix - Error when enabling image choices without uploading image in checkbox.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - 2.0.0       - xx-xx-2023
 * Fix 		  - Repeater field issue when exporting the CSV.
+* Fix 		  - Error when enabling image choices without uploading image in checkbox.
 * Fix 		  - Smart tag {first_name} {last_name} are not working.
 * Fix 		  - Form not showing to export the form while storing entry information is disabled.
 * Fix 		  - CSV export issue.

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1757,7 +1757,7 @@ abstract class EVF_Form_Fields {
 							array(
 								'slug'        => 'denied_domains',
 								'value'       => esc_attr( $denied_domains ),
-								'placeholder' => esc_attr__( 'Denied Domain(s)', 'everest-forms' )
+								'placeholder' => esc_attr__( 'Denied Domain(s)', 'everest-forms' ),
 							),
 							false
 						),
@@ -2404,7 +2404,7 @@ abstract class EVF_Form_Fields {
 						if ( 'words' === $field['limit_mode'] && $field['limit_count'] < str_word_count( $field_submit ) ) {
 							/* translators: %s Number of max words. */
 							$validation_text = sprintf( esc_html__( 'This field contains at most %s words', 'everest-forms' ), $field['limit_count'] );
-						} elseif ( 'characters' === $field['limit_mode'] && $field['limit_count'] < mb_strlen( $field_submit ) ) {
+						} elseif ( 'characters' === $field['limit_mode'] && $field['limit_count'] < mb_strlen( $field_submit ) ) { //phpcs:ignore PHPCompatibility.ParameterValues.NewIconvMbstringCharsetDefault.NotSet
 							/* translators: %s Number of max characters. */
 							$validation_text = sprintf( esc_html__( 'This field contains at most %s characters', 'everest-forms' ), $field['limit_count'] );
 						}
@@ -2415,7 +2415,7 @@ abstract class EVF_Form_Fields {
 						if ( 'words' === $field['min_length_mode'] && $field['min_length_count'] > str_word_count( $field_submit ) ) {
 							/* translators: %s Number of minimum words. */
 							$validation_text = sprintf( esc_html__( 'This field contains at least %s words', 'everest-forms' ), $field['min_length_count'] );
-						} elseif ( 'characters' === $field['min_length_mode'] && $field['min_length_count'] > mb_strlen( $field_submit ) ) {
+						} elseif ( 'characters' === $field['min_length_mode'] && $field['min_length_count'] > mb_strlen( $field_submit ) ) { //phpcs:ignore PHPCompatibility.ParameterValues.NewIconvMbstringCharsetDefault.NotSet
 							/* translators: %s Number of minimum characters. */
 							$validation_text = sprintf( esc_html__( 'This field contains at least %s characters', 'everest-forms' ), $field['min_length_count'] );
 						}

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -1972,7 +1972,7 @@ abstract class EVF_Form_Fields {
 						foreach ( $values as $value ) {
 							$default     = isset( $value['default'] ) ? $value['default'] : '';
 							$selected    = checked( '1', $default, false );
-							$placeholder = wp_remote_get( evf()->plugin_url( 'assets/images/everest-forms-placeholder.png' ), array( 'sslverify' => false ) );
+							$placeholder = evf()->plugin_url( 'assets/images/everest-forms-placeholder.png' );
 							$image_src   = ! empty( $value['image'] ) ? esc_url( $value['image'] ) : $placeholder;
 							$item_class  = array();
 

--- a/readme.txt
+++ b/readme.txt
@@ -419,6 +419,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 
 - 2.0.0       - xx-xx-2023
 * Fix 		  - Repeater field issue when exporting the CSV.
+* Fix 		  - Error when enabling image choices without uploading image in checkbox.
 * Fix 		  - Smart tag {first_name} {last_name} are not working.
 * Fix 		  - Form not showing to export the form while storing entry information is disabled.
 * Fix 		  - CSV export issue.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This pull request addresses an issue where an error was occurring in the form when a checkbox was dragged and dropped and the "enable image choices" option was selected but no image was uploaded. With this PR, the issue is resolved.


### How to test the changes in this Pull Request:

1. Create a form.
2. Drag and Drop the checkbox field and enable image choice.
3. save and reload the builder verify if the error shown in the debug log or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error when enabling image choices without uploading image in checkbox.
