### PR TITLE
Fix - Form not showing to export the form while storing entry information is disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - 2.0.0       - xx-xx-2023
 * Fix 		  - Repeater field issue when exporting the CSV.
+* Fix 		  - Form not showing to export the form while storing entry information is disabled.
 * Fix 		  - CSV export issue.
 * Fix 		  - Unnecessary JS Load on Frontend.
 * Enhancement - Send CSV in email.

--- a/includes/admin/views/html-admin-page-export.php
+++ b/includes/admin/views/html-admin-page-export.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 	<p><?php esc_html_e( 'Export your forms along with their settings as JSON file.', 'everest-forms' ); ?></p>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=evf-tools&tab=export' ) ); ?>">
 		<?php
-		$forms = evf_get_all_forms( true );
+		$forms = evf_get_all_forms( true, false );
 		if ( ! empty( $forms ) ) {
 			echo '<select id="everest-forms-form-export" class="evf-enhanced-select" style="min-width: 350px;" name="form_ids[]" data-placeholder="' . esc_attr__( 'Select Form(s)', 'everest-forms' ) . '" multiple>';
 			foreach ( $forms as $id => $form ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1130,7 +1130,7 @@ function evf_get_random_string( $length = 10 ) {
  * @param  bool $skip_disabled_entries True to skip disabled entries.
  * @return array of form data.
  */
-function evf_get_all_forms( $skip_disabled_entries = false ) {
+function evf_get_all_forms( $skip_disabled_entries = false, $check_disable_storing_entry_info = true ) {
 	$forms    = array();
 	$form_ids = wp_parse_id_list(
 		evf()->form->get_multiple(
@@ -1150,7 +1150,9 @@ function evf_get_all_forms( $skip_disabled_entries = false ) {
 			$form_data = ! empty( $form->post_content ) ? evf_decode( $form->post_content ) : '';
 
 			if ( ! $form || ( $skip_disabled_entries && count( $entries ) < 1 ) && ( isset( $form_data['settings']['disabled_entries'] ) && '1' === $form_data['settings']['disabled_entries'] ) ) {
-				continue;
+				if( ! $form || $check_disable_storing_entry_info ) {
+					continue;
+				}
 			}
 
 			// Check permissions for forms with viewable.

--- a/readme.txt
+++ b/readme.txt
@@ -419,6 +419,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 
 - 2.0.0       - xx-xx-2023
 * Fix 		  - Repeater field issue when exporting the CSV.
+* Fix 		  - Form not showing to export the form while storing entry information is disabled.
 * Fix 		  - CSV export issue.
 * Fix 		  - Unnecessary JS Load on Frontend.
 * Enhancement - Send CSV in email.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the issue of is form not showing in the  Tools > Export Everest Forms with Settings when the Disable storing entry information option is enabled in the form settings.

### How to test the changes in this Pull Request:

1. Verify whether the above-mentioned issue is fixed or not.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form not showing to export the form while storing entry information is disabled.
