### PR TITLE
 Fix - Repeater field issue when exporting the CSV.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 
 - 2.0.0       - xx-xx-2023
+* Fix 		  - Repeater field issue when exporting the CSV.
 * Enhancement - Send CSV in email.
 
 - 1.9.9       - 28-03-2023

--- a/includes/export/class-evf-entry-csv-exporter.php
+++ b/includes/export/class-evf-entry-csv-exporter.php
@@ -312,13 +312,43 @@ class EVF_Entry_CSV_Exporter extends EVF_CSV_Exporter {
 
 						foreach ( $fields[ $column_id ]['value_raw'] as $field_value ) {
 							foreach ( $field_value as $key => $val ) {
+								$repeater_field_value = '';
 								if ( isset( $repeater_fields[ $val['id'] ] ) ) {
-									$repeater_fields[ $val['id'] ]['value'] .= ', ' . $val['value'];
+									$repeater_field_type = isset( $repeater_fields[ $val['id'] ]['type'] ) ? $repeater_fields[ $val['id'] ]['type'] : '';
+									switch ( $repeater_field_type ) {
+										case 'checkbox':
+										case 'payment-checkbox':
+											$value                 = $val['value']['label'];
+											$value                 = implode( ', ', $value );
+											$repeater_field_value  = implode( ', ', $repeater_fields[ $val['id'] ]['value']['label'] );
+											$repeater_field_value .= ', ' . $value;
+											break;
+										case 'radio':
+										case 'payment-multiple':
+											$repeater_field_value  = $repeater_fields[ $val['id'] ]['value']['label'];
+											$repeater_field_value .= ', ' . $val['value']['label'];
+											break;
+										case 'select':
+											$value = $val['value'];
+											if ( is_array( $value ) ) {
+												$value = implode( ',', $value );
+											} else {
+												$value = $value;
+											}
+											$repeater_field_value  = implode( ', ', $repeater_fields[ $val['id'] ]['value'] );
+											$repeater_field_value .= ', ' . $value;
+											break;
+										default:
+											$repeater_field_value  = $repeater_fields[ $val['id'] ]['value'];
+											$repeater_field_value .= ', ' . $val['value'];
+											break;
+									}
 								} else {
 									$repeater_fields[ $val['id'] ] = $val;
 								}
-								$fields[ $key ]['value'] = $repeater_fields[ $val['id'] ]['value'];
-								$labels []               = $val['name'];
+								 $fields[ $key ]['value'] = $repeater_field_value;
+								$labels []                = isset( $val['name'] ) ? $val['name'] : $val['value']['name'];
+
 							}
 						}
 

--- a/readme.txt
+++ b/readme.txt
@@ -418,6 +418,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 == Changelog ==
 
 - 2.0.0       - xx-xx-2023
+* Fix 		  - Repeater field issue when exporting the CSV.
 * Enhancement - Send CSV in email.
 
 - 1.9.9       - 28-03-2023


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously exporting a CSV file with a repeater field caused issues where fields such as checkboxes, dropdown, and select were not displayed. This PR solves this issue.


### How to test the changes in this Pull Request:

1. Create a form with repeater fields.
2.  submit the form by repeating the field more than 1 time.
3. Export the CSV and verify if the issue is solved or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Repeater field issue when exporting the CSV.
