### PR TITLE
Fix- PDF download link not showing issue with paypal.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix 		  - Unnecessary JS Load on Frontend.
 * Fix 		  - Payment status is not showing in CSV.
 * Fix 		  - Minimum word count error message issue.
+* Fix		  - PDF download link not showing issue with paypal.
 * Enhancement - Send CSV in email.
 * Enhancement - Next Previous link on single entry view admin page.
 * Enhancement - Timezone selection for DateTime field.

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -956,9 +956,19 @@ class EVF_Shortcode_Form {
 		&& evf()->task->is_valid_hash
 		&& absint( evf()->task->form_data['id'] ) === $form_id
 		) {
-			// Output success message if no redirection happened.
+			$query_args = base64_decode( $_GET['everest_forms_return'] ); // phpcs:ignore
+			parse_str( $query_args, $query_arg );
+			$message        = isset( $form_data['settings']['successful_form_submission_message'] ) ? $form_data['settings']['successful_form_submission_message'] : esc_html__( 'Thanks for contacting us! We will be in touch with you shortly.', 'everest-forms' );
+			$pdf_submission = isset( $form_data['settings']['pdf_submission']['enable_pdf_submission'] ) && 0 !== $form_data['settings']['pdf_submission']['enable_pdf_submission'] ? $form_data['settings']['pdf_submission'] : '';
+			if ( defined( 'EVF_PDF_SUBMISSION_VERSION' ) && ( 'yes' === get_option( 'everest_forms_pdf_download_after_submit', 'no' ) || ( isset( $pdf_submission['everest_forms_pdf_download_after_submit'] ) && 'yes' === $pdf_submission['everest_forms_pdf_download_after_submit'] ) ) ) {
+				global $__everest_form_id;
+				global $__everest_form_entry_id;
+				$__everest_form_id       = $form_id;
+				$__everest_form_entry_id = isset( $query_arg['entry_id'] ) ? $query_arg['entry_id'] : 0;
+			}
+
 			if ( 'same' === $form_data['settings']['redirect_to'] ) {
-				evf_add_notice( isset( $form_data['settings']['successful_form_submission_message'] ) ? $form_data['settings']['successful_form_submission_message'] : esc_html__( 'Thanks for contacting us! We will be in touch with you shortly.', 'everest-forms' ), 'success' );
+				evf_add_notice( $message, 'success' );
 			}
 
 			do_action( 'everest_forms_frontend_output_success', evf()->task->form_data, evf()->task->form_fields, evf()->task->entry_id );

--- a/readme.txt
+++ b/readme.txt
@@ -426,6 +426,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 * Fix 		  - Unnecessary JS Load on Frontend.
 * Fix 		  - Payment status is not showing in CSV.
 * Fix 		  - Minimum word count error message issue.
+* Fix		  - PDF download link not showing issue with paypal.
 * Enhancement - Send CSV in email.
 * Enhancement - Next Previous link on single entry view admin page.
 * Enhancement - Timezone selection for DateTime field.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:
Previously, When we pay through PayPal and return backs to the  Pdf download link is not shown in the success message.

### How to test the changes in this Pull Request:

1. Create a form with PayPal Payment.
2.  Go to the Setting>PDf Submission and Enable download after submission.
3. Submit the form and pay with Paypal and when we return to the form the pdf download link is shown or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix- PDF download link not showing issue with PayPal.
