### PR TITLE
Added an event to control the Ajax submission process

### DIFF
--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -31,6 +31,13 @@ jQuery( function( $ ) {
 						return false;
 					}
 
+					// Let other plugins or integrations stop the submit process and do other things if needed.
+					var beforeSubmitEvent = $.Event( 'evf-frontend-ajax-submission-before-submit' );
+					formTuple.trigger( beforeSubmitEvent );
+					if ( beforeSubmitEvent.isDefaultPrevented() ) {
+						return false;
+					}
+
 					var data = formTuple.serializeArray();
 					e.preventDefault();
 					// We let the bubbling events in form play itself out.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Ajax submission process works perfectly but has one problem. You have no option if you want to do something before the Ajax submission is sent. The JavaScript will trigger `submit` on the form, which can be used to do something, but it will not stop the execution of the Ajax submission, even if `preventDefault()` and other methods are called on the event.

To solve this issue, I've added a custom event to stop the execution of the Ajax submission process if it is required for another plugin or integration.

I use this event for the mosparo Integration plugin, which is a spam protection tool ([mosparo.io](https://mosparo.io)). The Ajax submission process does not check the `isDefaultPrevented` on the `submit` event, which mosparo usually uses.

#### Additional remarks

- In the CONTRIBUTING.md file, you write that a pull request should be created by comparing to the master branch. But as far as I can tell, the master branch does not contain the latest released version. Please let me know if I should send the pull request compared to the master branch.
- I wasn't sure if I should update the minified file. If yes, please let me know. 

### How to test the changes in this Pull Request:

1. Create an event handler on the form for the event `evf-frontend-ajax-submission-before-submit`
2. The event handler should call `preventDefault()` on the event
3. If you try to submit a form with the Ajax submission enabled, the form should not be submitted.
4. If you comment the `preventDefault()`, the form should be submitted as usual

```javascript
jQuery( 'form' ).on( 'evf-frontend-ajax-submission-before-submit', function ( ev ) {
    ev.preventDefault();
    console.log( 'Submission blocked' );
});
```

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added an event to stop the Ajax submission.

