### PR TITLE
EVF-815 Fix - Issue with downloading AI Contact Form Addon

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -95,7 +95,7 @@ defined( 'ABSPATH' ) || exit;
 								$release      = wp_remote_retrieve_body( $response );
 								$release      = json_decode( $release, true );
 								$latest_tag   = isset( $release['tag_name'] ) ? esc_attr( $release['tag_name'] ) : '';
-								$download_url = "https://github.com/wpeverest/ai-contact-form/releases/latest/download/ai-contact-form.zip";
+								$download_url = 'https://github.com/wpeverest/ai-contact-form/releases/latest/download/ai-contact-form.zip';
 								?>
 									<?php if ( is_plugin_active( $addon_slug . '/' . $addon_slug . '.php' ) ) : ?>
 												<?php

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -95,7 +95,7 @@ defined( 'ABSPATH' ) || exit;
 								$release      = wp_remote_retrieve_body( $response );
 								$release      = json_decode( $release, true );
 								$latest_tag   = isset( $release['tag_name'] ) ? esc_attr( $release['tag_name'] ) : '';
-								$download_url = "https://github.com/wpeverest/ai-contact-form/archive/{$latest_tag}.zip";
+								$download_url = "https://github.com/wpeverest/ai-contact-form/releases/latest/download/ai-contact-form.zip";
 								?>
 									<?php if ( is_plugin_active( $addon_slug . '/' . $addon_slug . '.php' ) ) : ?>
 												<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when downloading the AI Contact Form both from the free and pro version of our plugin, a plugin file with the name ai-contact-form-1.0.0.zip would be downloaded which poses a problem when installing and running the plugin file. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Try downloading and installing the addon from both free and pro versions of our plugin.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue with downloading AI Contact Form Addon.
