### PR TITLE
Fix - PayPal redirection issue when Stripe and PayPal both is enabled.

### DIFF
--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -106,6 +106,13 @@ jQuery( function( $ ) {
 							window.location = redirect_url;
 							return;
 						}
+					if (xhr && xhr.payment_method && xhr.payment_method === 'paypal' && xhr.redirect) {
+						if ('paypal' === xhr.payment_method) {
+							window.location.href = xhr.redirect;
+							return;
+						}
+					}
+
 						if ( 'success' === xhr.data.response || true === xhr.success ) {
 							let pdf_download_message = '';
 							let quiz_reporting = '';
@@ -117,7 +124,6 @@ jQuery( function( $ ) {
 							}
 
 							var paymentMethod = formTuple.find( ".everest-forms-stripe-gateways-tabs .evf-tab" ).has( 'a.active' ).data( 'gateway' );
-
 
 							if(undefined === paymentMethod) {
 								paymentMethod = formTuple.find( ".everest-forms-gateway[data-gateway='ideal']" ).data( 'gateway' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, when both Stripe and PayPal were enabled, the PayPal payment was not redirecting to the PayPal account. This PR solves this issue.

### Dependent PR
[PR](https://github.com/wpeverest/everest-forms-pro/pull/820)

### How to test the changes in this Pull Request:

1. Create a Form.
2. Enable Both PayPal and Stripe Payments.
3. Verify whether Both are working or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - PayPal redirection issue when Stripe and PayPal both is enabled.