### PR TITLE
Fix - PHP 8.2 dynamic properties are deprecated.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Upgraded    - Input mask library.
 * Fix		  - Empty values in entries for (select, checkbox, radio) fields when wordPress site is in another language.
 * Fix         - XLSX export issue.
+* Fix 		  - PHP 8.2 dynamic properties are deprecated.
 * Feature 	  - Akismet integration.
 
 = 2.0.5       - 08-11-2023

--- a/includes/abstracts/class-evf-form-fields.php
+++ b/includes/abstracts/class-evf-form-fields.php
@@ -28,6 +28,13 @@ abstract class EVF_Form_Fields {
 	public $type;
 
 	/**
+	 * Field Order.
+	 *
+	 * @var string
+	 */
+	public $order;
+
+	/**
 	 * Field icon.
 	 *
 	 * @var mixed
@@ -40,6 +47,20 @@ abstract class EVF_Form_Fields {
 	 * @var string
 	 */
 	public $class = '';
+
+	/**
+	 * Field addon.
+	 *
+	 * @var string
+	 */
+	public $addon;
+
+	/**
+	 * Field plan.
+	 *
+	 * @var string
+	 */
+	public $plan;
 
 	/**
 	 * Form ID.

--- a/includes/class-everest-forms.php
+++ b/includes/class-everest-forms.php
@@ -46,6 +46,21 @@ final class EverestForms {
 	public $form;
 
 	/**
+	 * The form task handler instance.
+	 *
+	 * @var EVF_Form_Task
+	 */
+	public $task;
+
+
+	/**
+	 * The smart tags handler instance.
+	 *
+	 * @var EVF_Smart_Tags
+	 */
+	public $smart_tags;
+
+	/**
 	 * The entry data handler instance.
 	 *
 	 * @var EVF_Entry_Handler

--- a/readme.txt
+++ b/readme.txt
@@ -421,6 +421,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 * Upgraded    - Input mask library.
 * Fix		  - Empty values in entries for (select, checkbox, radio) fields when wordPress site is in another language.
 * Fix         - XLSX export issue.
+* Fix 		  - PHP 8.2 dynamic properties are deprecated.
 * Feature 	  - Akismet integration.
 
 = 2.0.5       - 08-11-2023


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, when we installed Everest forms on a PHP 8.2 version, dynamic property error messages were displayed.

### How to test the changes in this Pull Request:

1. Install the PHP 8.2 version.
2. Install the Everest Forms and check whether the depreciated messages are gone.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - PHP 8.2 dynamic properties are deprecated.
