### PR TITLE
Enhancement: Added a new 'active' class to active input field forms

### DIFF
--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -33,7 +33,9 @@ jQuery( function ( $ ) {
 			this.validateMinimumWordLength();
 
 			// Inline validation.
-			this.$everest_form.on( 'input validate change', '.input-text, select, input:checkbox, input:radio', this.validate_field );
+			this.$everest_form.on('input click validate change', '.input-text, select, input:checkbox, input:radio', this.validate_field, function() {
+				$('.input-text').addClass('evf-field-active');
+			});
 
 			// Notify plugins that the core was loaded.
 			$( document.body ).trigger( 'everest_forms_loaded' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:
1. Previously, while clicking on the input field there was no distinction between active and inactive form input field.

### How to test the changes in this Pull Request:
1. Create a form.
3. Preview the created form.
4. Inspect the active input field.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enhancement: Added a new 'active' class to active input field forms
