### PR TITLE
Fix - Show Values Setting Not Displaying in Select Field.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Enhancement - Clone email form settings.
 * Feature     - Email preview.
 * Fix 		  - Critical error in entry file.
+* Fix         - Show values setting not displaying in select field.
 
 = 2.0.6       - 26-12-2023
 * Upgraded    - Input mask library.

--- a/includes/fields/class-evf-field-select.php
+++ b/includes/fields/class-evf-field-select.php
@@ -55,6 +55,7 @@ class EVF_Field_Select extends EVF_Form_Fields {
 			'advanced-options' => array(
 				'field_options' => array(
 					'size',
+					'show_values',
 					'placeholder',
 					'label_hide',
 					'css',
@@ -142,6 +143,33 @@ class EVF_Field_Select extends EVF_Form_Fields {
 		}
 
 		return $properties;
+	}
+
+
+	/**
+	 * Show values field option.
+	 *
+	 * @param array $field Field Data.
+	 */
+	public function show_values( $field ) {
+		// Show Values toggle option. This option will only show if already used or if manually enabled by a filter.
+		if ( ! empty( $field['show_values'] ) || apply_filters( 'everest_forms_fields_show_options_setting', false ) ) {
+			$args = array(
+				'slug'    => 'show_values',
+				'content' => $this->field_element(
+					'checkbox',
+					$field,
+					array(
+						'slug'    => 'show_values',
+						'value'   => isset( $field['show_values'] ) ? $field['show_values'] : '0',
+						'desc'    => __( 'Show Values', 'everest-forms' ),
+						'tooltip' => __( 'Check this to manually set form field values.', 'everest-forms' ),
+					),
+					false
+				),
+			);
+			$this->field_element( 'row', $field, $args );
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -422,6 +422,8 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 * Enhancement - Clone email form settings.
 * Feature     - Email preview.
 * Fix 		  - Critical error in entry file.
+* Fix         - Show values setting not displaying in select field.
+
 
 = 2.0.6       - 26-12-2023
 * Upgraded    - Input mask library.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When use the filter to show the setting of show value. The Show setting does not shows up. This PR fixes this issue.


### How to test the changes in this Pull Request:

1. Create a form.
2. Add this filter in function.php file.
add_filter('everest_forms_fields_show_options_setting', function() {
    return true;
});

3. Drag and Drop the select field.
4. Go to Advance setting and enable show values.
5. Verify the show values box shows or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Show Values Setting Not Displaying in Select Field.
