### PR TITLE
Fix - Restrict font_url for unauthorized users and allow only certain font_url.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+
+= 2.0.8       - xx-xx-2024
+* Fix - Restrict font_url for unauthorized users and allow only certain font_url.
+
 = 2.0.7       - 22-02-2024
 * Enhancement - Screenshot video on upgrade to pro popup.
 * Enhancement - Clone email form settings.

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -104,7 +104,7 @@ class EVF_AJAX {
 			'locate_form_action'      => false,
 			'slot_booking'            => true,
 			'active_addons'           => false,
-			'get_local_font_url'      => true,
+			'get_local_font_url'      => false,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -1003,6 +1003,14 @@ class EVF_AJAX {
 	 */
 	public static function get_local_font_url() {
 		$font_url = isset( $_POST['font_url'] ) ? sanitize_text_field( wp_unslash( $_POST['font_url'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification
+
+		$allowed_urls = array(
+			'https://fonts.googleapis.com',
+		);
+
+		if ( ! in_array( $font_url, $allowed_urls ) ) {
+			return;
+		}
 
 		if ( str_contains( $font_url, 'https://fonts.googleapis.com' ) ) {
 			$font_url = evf_maybe_get_local_font_url( $font_url );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When we enable the setting font load locally then and then any one can replace our server with their own server and send the request. This PR solves this issue.

### How to test the changes in this Pull Request:

1.   Login to administrator. Go to Everest Forms in left panel, then go Settings -> Misc
2. Enable [Load Fonts Locally] mode.
3.  Replace [YOUR SERVER] part with your own listen-server (Beeceptor, Burp collaborator, ...) and send the following raw request
4. POST /wp-admin/admin-ajax.php HTTP/1.1
Host: localhost
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0
Content-Type: application/x-www-form-urlencoded; charset=UTF-8
X-Requested-With: XMLHttpRequest
Content-Length: 118

action=everest_forms_get_local_font_url&font_url=https://[YOUR SERVER]#https://fonts.googleapis.com/

5. Then a http request would be called to you listen server.
6. Verify if the issue is fixed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Restrict font_url for unauthorized users and allow only certain font_url.