### PR TITLE
Tweak - Hidden field editable compatibility

### DIFF
--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -974,6 +974,8 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 	$id    = trim( $id );
 	$parts = array();
 
+	$is_edit_entry = isset( $_GET['edit-entry'] ) && ! empty( sanitize_text_field( wp_unslash( $_GET['edit-entry'] ) ) ) ? true : false;
+
 	if ( ! empty( $id ) ) {
 		$id = sanitize_html_class( $id );
 		if ( ! empty( $id ) ) {
@@ -984,6 +986,10 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 	if ( ! empty( $class ) ) {
 		$class = evf_sanitize_classes( $class, true );
 		if ( ! empty( $class ) ) {
+			// While editing hidden field should be visible.
+			if( $is_edit_entry ){
+				$class   = str_replace( "evf-field-hidden", "", $class );
+			}
 			$parts[] = 'class="' . $class . '"';
 		}
 	}
@@ -994,7 +1000,6 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 		}
 	}
 
-	$is_edit_entry = isset( $_GET['edit-entry'] ) && ! empty( sanitize_text_field( wp_unslash( $_GET['edit-entry'] ) ) ) ? true : false;
 	if ( ! empty( $atts ) ) {
 		foreach ( $atts as $att => $val ) {
 			if ( '0' === $val || ! empty( $val ) ) {
@@ -1004,6 +1009,7 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 				} else {
 					$escaped_att = sanitize_html_class( $att );
 				}
+				// While editing, fields must be visible even if they are hidden.
 				if ( 'style' == $escaped_att && $is_edit_entry ) {
 					$parts[] = 'style = "display: block"';
 				} else {

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -974,7 +974,7 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 	$id    = trim( $id );
 	$parts = array();
 
-	$is_edit_entry = isset( $_GET['edit-entry'] ) && !  sanitize_text_field( wp_unslash( empty( $_GET['edit-entry'] ) ) ) ? true : false;
+	$is_edit_entry = isset( $_GET['edit-entry'] ) && ! sanitize_text_field( wp_unslash( empty( $_GET['edit-entry'] ) ) ) ? true : false;
 
 	if ( ! empty( $id ) ) {
 		$id = sanitize_html_class( $id );
@@ -987,7 +987,7 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 		$class = evf_sanitize_classes( $class, true );
 		if ( ! empty( $class ) ) {
 			// While editing hidden field should be visible.
-			if( $is_edit_entry ) {
+			if ( $is_edit_entry ) {
 				$class   = str_replace( 'evf-field-hidden', '', $class );
 			}
 			$parts[] = 'class="' . $class . '"';

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -974,7 +974,7 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 	$id    = trim( $id );
 	$parts = array();
 
-	$is_edit_entry = isset( $_GET['edit-entry'] ) && ! empty( sanitize_text_field( wp_unslash( $_GET['edit-entry'] ) ) ) ? true : false;
+	$is_edit_entry = isset( $_GET['edit-entry'] ) && !  sanitize_text_field( wp_unslash( empty( $_GET['edit-entry'] ) ) ) ? true : false;
 
 	if ( ! empty( $id ) ) {
 		$id = sanitize_html_class( $id );
@@ -987,8 +987,8 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 		$class = evf_sanitize_classes( $class, true );
 		if ( ! empty( $class ) ) {
 			// While editing hidden field should be visible.
-			if( $is_edit_entry ){
-				$class   = str_replace( "evf-field-hidden", "", $class );
+			if( $is_edit_entry ) {
+				$class   = str_replace( 'evf-field-hidden', '', $class );
 			}
 			$parts[] = 'class="' . $class . '"';
 		}

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -994,6 +994,7 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 		}
 	}
 
+	$is_edit_entry = isset( $_GET['edit-entry'] ) && ! empty( sanitize_text_field( wp_unslash( $_GET['edit-entry'] ) ) ) ? true : false;
 	if ( ! empty( $atts ) ) {
 		foreach ( $atts as $att => $val ) {
 			if ( '0' === $val || ! empty( $val ) ) {
@@ -1003,7 +1004,11 @@ function evf_html_attributes( $id = '', $class = array(), $datas = array(), $att
 				} else {
 					$escaped_att = sanitize_html_class( $att );
 				}
-				$parts[] = $escaped_att . '="' . esc_attr( $val ) . '"';
+				if ( 'style' == $escaped_att && $is_edit_entry ) {
+					$parts[] = 'style = "display: block"';
+				} else {
+					$parts[] = $escaped_att . '="' . esc_attr( $val ) . '"';
+				}
 			}
 		}
 	}

--- a/includes/fields/class-evf-field-hidden.php
+++ b/includes/fields/class-evf-field-hidden.php
@@ -82,9 +82,14 @@ class EVF_Field_Hidden extends EVF_Form_Fields {
 		// Define data.
 		$primary = $field['properties']['inputs']['primary'];
 
+		// For edit purpose.
+		$is_edit_entry = isset( $_GET['edit-entry'] ) && sanitize_text_field( wp_unslash( $_GET['edit-entry'] ) ) ? true : false;
+		$field_type    = $is_edit_entry ? 'text' : 'hidden';
+
 		// Primary field.
 		printf(
-			'<input type="hidden" %s>',
+			'<input type="%s" %s>',
+			$field_type,
 			evf_html_attributes( $primary['id'], $primary['class'], $primary['data'], $primary['attr'] )
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, hidden field are not editable. This PR add this feature.

### How to test the changes in this Pull Request:

Dependency PR : [PRO PR](https://github.com/wpeverest/everest-forms-pro/pull/939)
1. Create a form and drag hidden field or make any field hidden.
2. Preview form and submit form.
3. Go to Everest Forms > Entries > view entry and edit that entry.
4.  Check whether you can edit hidden field or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Hidden field editable compatibility
