### PR TITLE
Fix - Focus on last error message on form validation

### DIFF
--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -49,7 +49,14 @@ jQuery( function ( $ ) {
 
 	;
 
-
+			/**
+			 * Focus on first error on submit.
+			 *
+			 * @since xx.xx.xx
+			 */
+			this.$everest_form.on( 'submit', function(){
+				everest_forms.onSubmitErrorScroll();
+			})
 
 			$( document.body ).trigger( 'everest_forms_loaded' );
 		},
@@ -731,6 +738,20 @@ jQuery( function ( $ ) {
 				}, 1000 );
 			}
 		},
+		
+		/**
+		 * Focus on first error on submit.
+		 *
+		 * @since xx.xx.xx
+		 */
+		onSubmitErrorScroll: function(){
+			if ( $( '.everest-forms-invalid' ).length ) {
+				$( 'html,body' ).animate( {
+					scrollTop: ( $( '.everest-forms-invalid' )[0].offset().top ) - 100
+				}, 1000 );
+			}
+		},
+
 		randomize_elements: function() {
 			$( '.everest-forms-randomize' ).each( function() {
 				var $list      = $( this ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When form is submitted without filling required field then it focus last error only. This PR allow to focus on first first error.

### How to test the changes in this Pull Request:

1. Make form having required field more than 10.
2. Submit without filling. 
3. Check whether it focus on first error or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Focus on last error message on form validation
