### PR TITLE
Fix - Slot booking while the custom format is set in the WordPress timezone.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 3.0.9.5     	- 20-02-2025
+* Fix           - Execution halted during arbitrary attack.
+* Fix           - Slot booking while the custom format is set in the WordPress timezone.
+
 = 3.0.9.4       	- 18-02-2025
 * Tweak 			- Open upgrade to pro to new tab from submenu.
 * Fix 				- Sanitization filename issue in temporary path.

--- a/everest-forms.php
+++ b/everest-forms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Everest Forms
  * Plugin URI: https://everestforms.net/
  * Description: Best WordPress Form Plugin to Create Contact Forms, Surveys, Quizzes, Payment Forms, & Custom Forms Using Drag & Drop Form Builder.
- * Version: 3.0.9.4
+ * Version: 3.0.9.5
  * Author: Everest Forms
  * Author URI: https://everestforms.net/
  * Text Domain: everest-forms

--- a/includes/class-everest-forms.php
+++ b/includes/class-everest-forms.php
@@ -23,7 +23,7 @@ final class EverestForms {
 	 *
 	 * @var string
 	 */
-	public $version = '3.0.9.4';
+	public $version = '3.0.9.5';
 
 	/**
 	 * The single instance of the class.

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -4728,14 +4728,30 @@ function parse_datetime_values( $datetime_value, $datetime_format, $date_format,
 			break;
 		case 'date':
 			if ( 'range' === $mode ) {
+				$datetime_value = apply_filters( 'everest_forms_time_date_format', $datetime_value );
 				$selected_dates = explode( ' to ', $datetime_value );
 				if ( count( $selected_dates ) >= 2 ) {
-					$datetime_start = "$selected_dates[0] 00:00";
-					$datetime_start = gmdate( 'Y-m-d H:i', strtotime( $datetime_start ) );
-					$date_time      = new DateTime( $selected_dates[1] );
-					$date_time->modify( '+23 hour' );
-					$datetime_end              = $date_time->format( 'Y-m-d H:i' );
-					$datetime_arr[ $entry_id ] = array( $datetime_start, $datetime_end );
+					if ( count( $selected_dates ) >= 2 ) {
+						$start_date = DateTime::createFromFormat( $date_format, $selected_dates[0] );
+						if ( $start_date === false ) {
+							evf_get_logger()->debug( print_r( "Invalid start date format: {$selected_dates[0]}", true ) );
+						}
+						$start_date->setTime( 0, 0 );
+						$datetime_start = $start_date->format( 'Y-m-d H:i' );
+
+						$end_date = DateTime::createFromFormat( $date_format, $selected_dates[1] );
+						if ( $end_date === false ) {
+							evf_get_logger()->debug( print_r( "Invalid end date format: {$selected_dates[1]}", true ) );
+						}
+						$end_date->modify( '+23 hours' );
+						$datetime_end = $end_date->format( 'Y-m-d H:i' );
+
+						$datetime_arr[ $entry_id ] = array( $datetime_start, $datetime_end );
+					}
+				}else{
+					if ( !empty($datetime_value) && ! is_array ( $datetime_value) ) {
+						$datetime_arr[ $entry_id ] = $datetime_value ;
+					}
 				}
 			} else {
 				$selected_dates = explode( ', ', $datetime_value );
@@ -4753,6 +4769,7 @@ function parse_datetime_values( $datetime_value, $datetime_format, $date_format,
 			break;
 		case 'date-time':
 			if ( 'range' === $mode ) {
+				$datetime_value = apply_filters( 'everest_forms_time_date_format', $datetime_value );
 				$selected_dates = explode( ' to ', $datetime_value );
 				if ( count( $selected_dates ) >= 2 ) {
 					$datetime_start            = gmdate( 'Y-m-d H:i', strtotime( $selected_dates[0] ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: contact form, custom form, form builder, forms, survey
 Requires at least: 5.5
 Tested up to: 6.7.1
 Requires PHP: 7.2
-Stable tag: 3.0.9.4
+Stable tag: 3.0.9.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -307,6 +307,10 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 
 
 == Changelog ==
+
+= 3.0.9.5     	- 20-02-2025
+* Fix           - Execution halted during arbitrary attack.
+* Fix           - Slot booking while the custom format is set in the WordPress timezone.
 
 = 3.0.9.4       	- 18-02-2025
 * Tweak 			- Open upgrade to pro to new tab from submenu.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the issue of slot booking while the custom timezone is set in the WordPress.

Closes # .

### How to test the changes in this Pull Request:

1. Go WordPress Settings > General
2. Set the timezone as **Rome** for example and make the default language as the Italiano.
3. Make the **Date Format as j F Y** and the **Time Format as G:i**
4. Then go to **Everest Forms > Form** Drag and drop the date time field.
5. Make the Date field with range from the Advanced Options and then make the Date Localization as Italiano, Date time format as d/m/Y and Make the timezone Default.
6. Now check whether the slot booking is done accordingly or not by preventing the duplicate date selection.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Slot booking while the custom format is set in the WordPress timezone.