### PR TITLE
Enhance - Donot save form when redirection url in brevo is not valid

### DIFF
--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -343,6 +343,41 @@ class EVF_AJAX {
 			);
 		}
 
+		/**
+		 * Return when redirection url is not valid in Brevo redirection url.
+		 *
+		 * @since xx.xx.xx
+		 */
+		$send_in_blue_valid_url_count = 0;
+
+		if ( isset( $data['integrations']['sendinblue'] ) ) {
+			foreach ( $data['integrations']['sendinblue'] as $key => $value ) {
+				if ( isset( $value['options']['double_optin'] ) && $value['options']['double_optin'] && isset( $value['double_optin_redirection_url'] ) && ! empty( $value['double_optin_redirection_url'] ) ) {
+					$url_pattern = '/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/';
+
+					if ( preg_match( $url_pattern, $value['double_optin_redirection_url'] ) ) {
+						$send_in_blue_valid_url_count = $send_in_blue_valid_url_count;
+					} else {
+						$send_in_blue_valid_url_count += 1;
+					}
+				}
+			}
+		}
+
+		if ( $send_in_blue_valid_url_count > 0 ) {
+			$logger->error(
+				__( 'Invalid URL', 'everest-forms' ),
+				array( 'source' => 'form-save' )
+			);
+			wp_send_json_error(
+				array(
+					'errorTitle'   => esc_html__( 'Invalid URL', 'everest-forms' ),
+					/* translators: %s: empty meta data */
+					'errorMessage' => esc_html__( 'Please add valid url on Brevo redirection url', 'everest-forms' ),
+				)
+			);
+		}
+
 		if ( ! empty( $data['form_fields'] ) ) {
 			foreach ( $data['form_fields'] as $field_key => $field ) {
 				if ( ! empty( $field['label'] ) ) {

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -353,10 +353,10 @@ class EVF_AJAX {
 		if ( isset( $data['integrations']['sendinblue'] ) ) {
 			foreach ( $data['integrations']['sendinblue'] as $key => $value ) {
 				if ( isset( $value['options']['double_optin'] ) && $value['options']['double_optin'] && isset( $value['double_optin_redirection_url'] ) && ! empty( $value['double_optin_redirection_url'] ) ) {
-					$url_pattern = '/^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/';
+					$url_pattern = '/^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}([\/\?#][^\s]*)?$/';
 
 					if ( preg_match( $url_pattern, $value['double_optin_redirection_url'] ) ) {
-						$send_in_blue_valid_url_count = $send_in_blue_valid_url_count;
+						$send_in_blue_valid_url_count += 0;
 					} else {
 						$send_in_blue_valid_url_count += 1;
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, form save when redirection url is not valid in Brevo Double opt-in. This PR fix that issue.

### How to test the changes in this Pull Request:

1. Insert invalid url in Double Opt-in redirection url.
2. Save the form.
3. You will get error message on popup.
4. Verify it.

Note : Dependency PR [Pro](https://github.com/wpeverest/everest-forms-pro/pull/1014)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Stop form saving when redirection url in brevo is not valid url
