### PR TITLE
Enhance - Display the form submission message after form submission

### DIFF
--- a/assets/css/everest-forms.scss
+++ b/assets/css/everest-forms.scss
@@ -2004,3 +2004,56 @@ $background-color_1: #f9f9f9;
 	  }
 	}
   }
+
+  body .everest-forms-popup-overlay{
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 9999;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	.everest-forms-popup{
+		background: #fff;
+		padding: 20px 30px;
+		border-radius: 8px;
+		width: 386px;
+		height: 278px ;
+		text-align: center;
+		position: relative;
+		box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+
+		img.everest-forms-popup-success-logo{
+			margin-top: 54px;
+			margin-bottom: 24px;
+		}
+
+		p.everest-forms-popup-success-text{
+			font-size: 24px;
+			font-weight: 500;
+		}
+
+		p{
+			font-size: 15px;
+			font-weight: 400;
+			margin: 0;
+		}
+	}
+
+	.everest-forms-popup-close{
+		position: absolute;
+		top: 10px;
+		right: 15px;
+		font-size: 20px;
+		font-weight: bold;
+		color: #aaa;
+		cursor: pointer;
+		transition: color 0.3s;
+		margin-top: 24px;
+		margin-right: 24px;
+	}
+  }

--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -126,11 +126,12 @@ jQuery( function( $ ) {
 						}
 					}
 
-						if ( 'success' === xhr.data.response || true === xhr.success ) {
-							let pdf_download_message = '';
-							let quiz_reporting = '';
-							let preview_confirmation = '';
-							if(xhr.data.form_id !== undefined && xhr.data.entry_id !== undefined && xhr.data.pdf_download == true){
+					if ( 'success' === xhr.data.response || true === xhr.success ) {
+						let pdf_download_message = '';
+						let quiz_reporting = '';
+						let preview_confirmation = '';
+						let message_location = '';
+						if(xhr.data.form_id !== undefined && xhr.data.entry_id !== undefined && xhr.data.pdf_download == true){
 								pdf_download_message = '<br><small><a href="/?page=evf-entries-pdf&form_id='+ xhr.data.form_id+'&entry_id='+xhr.data.entry_id+'">' + xhr.data.pdf_download_message + '</a></small>';
 							}
 							if( xhr.data.quiz_result_shown == true){
@@ -141,6 +142,9 @@ jQuery( function( $ ) {
 								preview_confirmation = xhr.data.preview_confirmation;
 							}
 
+							if ( xhr.data.message_display_location !== undefined && xhr.data.message_display_location !== '' ) {
+								message_location = xhr.data.message_display_location;
+							}
 
 							var paymentMethod = formTuple.find( ".everest-forms-stripe-gateways-tabs .evf-tab" ).has( 'a.active' ).data( 'gateway' );
 
@@ -175,8 +179,29 @@ jQuery( function( $ ) {
 							}
 
 							formTuple.trigger( 'reset' );
-							formTuple.closest( '.everest-forms' ).html( '<div class="everest-forms-notice everest-forms-notice--success" role="alert">' + xhr.data.message + pdf_download_message + '</div>' + quiz_reporting + preview_confirmation ).focus();
-							localStorage.removeItem(formTuple.attr('id'));
+							formTuple.closest('.everest-forms').find('.everest-forms-notice').remove();
+
+							if (message_location === 'hide') {
+								formTuple.closest('.everest-forms').html(
+									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
+									xhr.data.message + pdf_download_message +
+									'</div>' + quiz_reporting + preview_confirmation
+								).focus();
+							} else if (message_location === 'top') {
+								formTuple.closest('.everest-forms').prepend(
+									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
+									xhr.data.message + pdf_download_message +
+									'</div>' + quiz_reporting + preview_confirmation
+								).focus();
+							} else if (message_location === 'bottom') {
+								formTuple.closest('.everest-forms').append(
+									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
+									xhr.data.message + pdf_download_message +
+									'</div>' + quiz_reporting + preview_confirmation
+								).focus();
+							}
+
+							btn.attr('disabled', false).html(everest_forms_ajax_submission_params.submit);
 
 							// Trigger for form submission success.
 							var event = new CustomEvent("everest_forms_ajax_submission_success", {

--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -181,19 +181,19 @@ jQuery( function( $ ) {
 							formTuple.trigger( 'reset' );
 							formTuple.closest('.everest-forms').find('.everest-forms-notice').remove();
 
-							if (message_location === 'hide') {
+							if ( 'hide' === message_location ) {
 								formTuple.closest('.everest-forms').html(
 									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
 									xhr.data.message + pdf_download_message +
 									'</div>' + quiz_reporting + preview_confirmation
 								).focus();
-							} else if (message_location === 'top') {
+							} else if ( 'top' === message_location) {
 								formTuple.closest('.everest-forms').prepend(
 									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
 									xhr.data.message + pdf_download_message +
 									'</div>' + quiz_reporting + preview_confirmation
 								).focus();
-							} else if (message_location === 'bottom') {
+							} else if ( 'bottom' === message_location ) {
 								formTuple.closest('.everest-forms').append(
 									'<div class="everest-forms-notice everest-forms-notice--success" role="alert">' +
 									xhr.data.message + pdf_download_message +

--- a/assets/js/frontend/ajax-submission.js
+++ b/assets/js/frontend/ajax-submission.js
@@ -199,6 +199,32 @@ jQuery( function( $ ) {
 									xhr.data.message + pdf_download_message +
 									'</div>' + quiz_reporting + preview_confirmation
 								).focus();
+							}else if ( 'popup' === message_location ) {
+								$('body').css('overflow', 'hidden');
+
+								var popupHTML = `
+									<div class="everest-forms-popup-overlay">
+										<div class="everest-forms-popup">
+											<div class="everest-forms-popup-close">
+												<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+												<path d="M7 6.06668L1.26666 0.333344L0.333328 1.20001L6.06666 6.93334L0.333328 12.6L1.26666 13.5333L7 7.86668L12.6667 13.5333L13.6 12.6L7.93333 6.93334L13.6667 1.33334L12.7333 0.466677L7 6.06668Z" fill="#383838"/>
+												</svg>
+											</div>
+											<img src="${ everest_forms_ajax_submission_params.evf_checked_image_url }" alt="Checked Logo" class="everest-forms-popup-success-logo">
+											<p class="everest-forms-popup-success-text">${ everest_forms_ajax_submission_params.i18n_evf_success_text }</p>
+											<p>${ xhr.data.message }</p>
+										</div>
+									</div>
+								`;
+
+								$('body').append(popupHTML);
+
+								$('.everest-forms-popup-close').on('click', function() {
+									$('.everest-forms-popup-overlay').fadeOut(200, function() {
+										$(this).remove();
+										$('body').css('overflow', '');
+									});
+								});
 							}
 
 							btn.attr('disabled', false).html(everest_forms_ajax_submission_params.submit);

--- a/assets/js/frontend/everest-forms.js
+++ b/assets/js/frontend/everest-forms.js
@@ -37,6 +37,7 @@ jQuery( function ( $ ) {
 				this.loadCountryFlags();
 				this.ratingInit();
 				this.FormSubmissionWaitingTime();
+				this.popUpMessage();
 			};
 
 			// Initial setup
@@ -1043,6 +1044,41 @@ jQuery( function ( $ ) {
 			});
 		},
 
+		popUpMessage: function() {
+			var $isPopup = $('.everest-form').is('[data-message_location]');
+
+			if ( ! $isPopup ) {
+				return;
+			}
+
+			var $message = $('.everest-form').data('message');
+
+			$('body').css('overflow', 'hidden');
+
+			var popupHTML = `
+				<div class="everest-forms-popup-overlay">
+					<div class="everest-forms-popup">
+						<div class="everest-forms-popup-close">
+							<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path d="M7 6.06668L1.26666 0.333344L0.333328 1.20001L6.06666 6.93334L0.333328 12.6L1.26666 13.5333L7 7.86668L12.6667 13.5333L13.6 12.6L7.93333 6.93334L13.6667 1.33334L12.7333 0.466677L7 6.06668Z" fill="#383838"/>
+							</svg>
+						</div>
+						<img src="${ everest_forms_params.evf_checked_image_url }" alt="Checked Logo" class="everest-forms-popup-success-logo">
+						<p class="everest-forms-popup-success-text">${ everest_forms_params.i18n_evf_success_text }</p>
+						<p>${ $message }</p>
+					</div>
+				</div>
+			`;
+
+			$('body').append(popupHTML);
+
+			$('.everest-forms-popup-close').on('click', function() {
+				$('.everest-forms-popup-overlay').fadeOut(200, function() {
+					$(this).remove();
+					$('body').css('overflow', '');
+				});
+			});
+		},
 
 		getFirstBrowserLanguage: function() {
 			var nav = window.navigator,

--- a/includes/admin/builder/class-evf-builder-settings.php
+++ b/includes/admin/builder/class-evf-builder-settings.php
@@ -608,6 +608,26 @@ class EVF_Builder_Settings extends EVF_Builder_Page {
 						'tooltip'     => sprintf( esc_html__( 'Success message that shows up after submitting form. <a href="%1$s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.everestforms.net/docs/general-settings/#4-toc-title' ) ),
 					)
 				);
+
+				everest_forms_panel_field(
+					'select',
+					'settings',
+					'successful_form_submission_message_display_location',
+					$this->form_data,
+					esc_html__( 'Success message display location', 'everest-forms' ),
+					array(
+						'default' => 'hide',
+						/* translators: %1$s - general settings docs url */
+						'tooltip' => sprintf( esc_html__( 'Choose where to display success message. <a href="%s" target="_blank">Learn More</a>', 'everest-forms' ), esc_url( 'https://docs.everestforms.net/docs/confirmations/' ) ),
+						'options' => array(
+							'hide'   => esc_html__( 'Hide form', 'everest-forms' ),
+							'top'    => esc_html__( 'Top', 'everest-forms' ),
+							'bottom' => esc_html__( 'Bottom', 'everest-forms' ),
+							'popup'  => esc_html__( 'Popup', 'everest-forms' ),
+						),
+					)
+				);
+
 				everest_forms_panel_field(
 					'toggle',
 					'settings',

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -622,6 +622,7 @@ class EVF_Form_Task {
 
 		if ( '1' === $ajax_form_submission ) {
 			$response_data['message']                   = $message;
+			$response_data['message_display_location']  = $message_display_location;
 			$response_data['response']                  = 'success';
 			$response_data['form_id']                   = $form_id;
 			$response_data['entry_id']                  = $entry_id;

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -586,6 +586,7 @@ class EVF_Form_Task {
 
 		$settings                  = $this->form_data['settings'];
 		$message                   = isset( $settings['successful_form_submission_message'] ) ? $settings['successful_form_submission_message'] : __( 'Thanks for contacting us! We will be in touch with you shortly.', 'everest-forms' );
+		$message_display_location  = isset( $settings['successful_form_submission_message_display_location'] ) ? $settings['successful_form_submission_message_display_location'] : 'hide';
 		$is_pdf_submission_enabled = isset( $settings['pdf_submission']['enable_pdf_submission'] ) && ( 'yes' === $settings['pdf_submission']['enable_pdf_submission'] || '1' === $settings['pdf_submission']['enable_pdf_submission'] );
 		$pdf_submission            = $is_pdf_submission_enabled ? $settings['pdf_submission'] : '';
 
@@ -674,7 +675,9 @@ class EVF_Form_Task {
 			delete_option( 'everest_forms_overall_feedback_is_called' );
 			return $response_data;
 		} elseif ( ( 'same' === $this->form_data['settings']['redirect_to'] && empty( $submission_redirection_process ) ) || ( ! empty( $submission_redirection_process ) && 'same_page' == $submission_redirection_process['redirect_to'] ) ) {
-			evf_add_notice( $message, 'success' );
+			if ( 'hide' === $message_display_location ) {
+				evf_add_notice( $message, 'success' );
+			}
 		}
 		$logger->info(
 			'Everest Forms After success Message.',

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -348,6 +348,8 @@ class EVF_Frontend_Scripts {
 					'error'               => esc_html__( 'Something went wrong while making an AJAX submission', 'everest-forms' ),
 					'required'            => esc_html__( 'This field is required.', 'everest-forms' ),
 					'pdf_download'        => esc_html__( 'Click here to download your pdf submission', 'everest-forms' ),
+					'evf_checked_image_url' 			   => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
+					'i18n_evf_success_text'				    => esc_html__( 'Success!', 'everest-forms' ),
 				);
 				break;
 			case 'everest-forms-survey-polls-quiz-script':

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -330,6 +330,8 @@ class EVF_Frontend_Scripts {
 					'i18n_messages_phone'                  => get_option( 'everest_forms_phone_validation', __( 'Please enter a valid phone number.', 'everest-forms' ) ),
 					'evf_smart_phone_allowed_countries'    => apply_filters( 'everest_forms_smart_phone_allowed_countries', array() ),
 					'i18n_field_rating_greater_than_max_value_error' => esc_html__( 'Please enter in a value less than 100.', 'everest-forms' ),
+					'evf_checked_image_url' 			   => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
+					'i18n_evf_success_text'				    => esc_html__( 'Success!', 'everest-forms' ),
 				);
 				break;
 			case 'everest-forms-text-limit':

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -997,8 +997,11 @@ class EVF_Shortcode_Form {
 			return;
 		}
 
+		$message_display_location  	= isset( $form_data['settings']['successful_form_submission_message_display_location'] ) ? $form_data['settings']['successful_form_submission_message_display_location'] : 'hide';
+		$message 					= isset( $form_data['settings']['successful_form_submission_message'] ) ? $form_data['settings']['successful_form_submission_message'] : __( 'Thanks for contacting us! We will be in touch with you shortly.', 'everest-forms' );
+
 		$success = apply_filters( 'everest_forms_success', false, $form_id );
-		if ( $success && ! empty( $form_data ) ) {
+		if ( $success && ! empty( $form_data ) && 'hide' === $message_display_location ) {
 			do_action( 'everest_forms_frontend_output_success', $form_data );
 			return;
 		}
@@ -1130,6 +1133,10 @@ class EVF_Shortcode_Form {
 		} elseif ( isset( $atts['type'] ) && 'popup' === $popup_type ) {
 			do_action( 'everest_form_popup', $atts );
 		} else {
+			if ( $success && ! empty( $form_data ) && 'top' === $message_display_location ) {
+				evf_add_notice( $message, 'success' );
+				do_action( 'everest_forms_frontend_output_success', $form_data );
+			}
 			echo '<form ' . evf_html_attributes( $form_atts['id'], $form_atts['class'], $form_atts['data'], $form_atts['atts'] ) . '>';
 			if ( evf_is_amp() ) {
 				$state = array(
@@ -1144,6 +1151,10 @@ class EVF_Shortcode_Form {
 			do_action( 'everest_forms_frontend_output', $form_data, $title, $description, $errors );
 
 			echo '</form>';
+			if ( $success && ! empty( $form_data ) && 'bottom' === $message_display_location ) {
+				evf_add_notice( $message, 'success' );
+				do_action( 'everest_forms_frontend_output_success', $form_data );
+			}
 		}
 
 		do_action( 'everest_forms_frontend_output_form_after', $form_data, $form );

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -1136,6 +1136,9 @@ class EVF_Shortcode_Form {
 			if ( $success && ! empty( $form_data ) && 'top' === $message_display_location ) {
 				evf_add_notice( $message, 'success' );
 				do_action( 'everest_forms_frontend_output_success', $form_data );
+			}elseif ( $success && ! empty( $form_data ) && 'popup' === $message_display_location ) {
+				$form_atts['data']['message_location'] = $message_display_location;
+				$form_atts['data']['message']        = $message;
 			}
 			echo '<form ' . evf_html_attributes( $form_atts['id'], $form_atts['class'], $form_atts['data'], $form_atts['atts'] ) . '>';
 			if ( evf_is_amp() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, Form hides on form submission. This PR adds the option to show message on top, bottom, popup and hide form.

### How to test the changes in this Pull Request:

1. Go to Form Builder > Confirmation > Choose the message location.
2. Verify whether success message are displaying in right place or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Display the form submission message after form submission
