### PR TITLE
Enhance - Validate clean talk access key on save to prevent invalid key behavior

### DIFF
--- a/addons/CleanTalk/Settings/Settings.php
+++ b/addons/CleanTalk/Settings/Settings.php
@@ -89,8 +89,9 @@ class Settings extends \EVF_Integration {
 							<input style="margin: 12px 0; width: 100%" class="evf-access-key" type="password" id="everest_forms_recaptcha_cleantalk_access_key" name="everest_forms_recaptcha_cleantalk_access_key" value="<?php echo esc_attr( get_option( 'everest_forms_recaptcha_cleantalk_access_key' ) ); ?>">
 							<p style="margin-bottom:0; margin-top:0"><?php echo __( 'Enter your CleanTalk REST API key from your ', 'everest-forms' ); ?><a href="https://cleantalk.org/my/" target="_blank" rel="noopener noreferrer"><?php echo __( 'account dashboard here', 'everest-forms' ); ?></a>.</p>
 						</div>
+						<div class="evf-clean-talk-message"></div>
 					</div>
-					<input style="margin-top: 12px;" type="submit" id="everest-forms-clean-talk-save-settings" class="everest-forms-btn everest-forms-btn-primary" value="<?php esc_attr_e( 'Save Settings', 'everest-forms' ); ?>">
+					<button style="margin-top: 12px;" type="submit" id="everest-forms-clean-talk-save-settings" class="everest-forms-btn everest-forms-btn-primary" ><?php echo __('Save Settings', 'everest-forms') ?></button>
 				 </form>
 
 				</div>

--- a/addons/CleanTalk/assets/js/admin/admin.js
+++ b/addons/CleanTalk/assets/js/admin/admin.js
@@ -75,6 +75,11 @@
 				beforeSend : function() {
 					var spinner = '<i class="evf-loading evf-loading-active"></i>';
 					$button.append( spinner );
+					$button.attr( 'disabled', true );
+					$button.css({
+						cursor: 'not-allowed',
+						opacity: 0.5
+					});
 				},
 				success: function (response) {
 					$button.find('.evf-loading').remove();
@@ -87,37 +92,31 @@
 						clearInterval(killUnloadPrompt);
 					}, 5000);
 
-					const $messageBox = $(document).find('.evf-clean-talk-message');
-
-					$messageBox.attr('style', '');
-					const baseStyle = `
-						padding: 10px 15px;
-						border-radius: 4px;
-						margin-top: 10px;
-						font-weight: bold;
-						display: block;
-					`;
+					const $messageBox = $( document ).find( '.evf-clean-talk-message' );
+					$messageBox.empty();
+					$messageBox.append( response.data.html );
 
 					if (response.success) {
-						$messageBox
-							.attr('style', baseStyle + `
-								color: #155724;
-								background-color: #d4edda;
-								border: 1px solid #c3e6cb;
-							`)
-							.text(response.data.message || 'Form submitted successfully!');
+						$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).addClass( 'everest-forms-clean-talk-success-state' );
 					} else {
-						$messageBox
-							.attr('style', baseStyle + `
-								color: #721c24;
-								background-color: #f8d7da;
-								border: 1px solid #f5c6cb;
-							`)
-							.text(response.data.message || 'An error occurred. Please try again.');
+						if ( 'empty' === response.data.error ) {
+							$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).addClass( 'everest-forms-clean-talk-empty-state' );
+						}else{
+							$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).addClass( 'everest-forms-clean-talk-invalid-state' );
+						}
 					}
+
+					$button.attr( 'disabled', false );
+					$button.css({
+						cursor: '',
+						opacity: 1
+					});
 
 					setTimeout(function () {
 						$messageBox.fadeOut(300, function () {
+							$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).removeClass( 'everest-forms-clean-talk-empty-state' );
+							$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).removeClass( 'everest-forms-clean-talk-invalid-state' );
+							$messageBox.find( '.everest-forms-clean-talk-message-outer-wrapper' ).removeClass( 'everest-forms-clean-talk-success-state' );
 							$messageBox.attr('style', '').text('').show();
 						});
 					}, 5000);

--- a/addons/CleanTalk/assets/js/admin/admin.js
+++ b/addons/CleanTalk/assets/js/admin/admin.js
@@ -67,14 +67,17 @@
 			};
 
 			const $button = $el;
-			const originalText = $button.val();
-			$button.prop('disabled', true).val('Saving...');
 
 			$.ajax({
 				type: 'POST',
 				url: everest_forms_clean_talk.ajax_url,
 				data: data,
+				beforeSend : function() {
+					var spinner = '<i class="evf-loading evf-loading-active"></i>';
+					$button.append( spinner );
+				},
 				success: function (response) {
+					$button.find('.evf-loading').remove();
 					const killUnloadPrompt = setInterval(function () {
 						window.onbeforeunload = null;
 						$(window).off('beforeunload');
@@ -84,19 +87,45 @@
 						clearInterval(killUnloadPrompt);
 					}, 5000);
 
+					const $messageBox = $(document).find('.evf-clean-talk-message');
+
+					$messageBox.attr('style', '');
+					const baseStyle = `
+						padding: 10px 15px;
+						border-radius: 4px;
+						margin-top: 10px;
+						font-weight: bold;
+						display: block;
+					`;
+
 					if (response.success) {
-						$button.val('Saved');
+						$messageBox
+							.attr('style', baseStyle + `
+								color: #155724;
+								background-color: #d4edda;
+								border: 1px solid #c3e6cb;
+							`)
+							.text(response.data.message || 'Form submitted successfully!');
+					} else {
+						$messageBox
+							.attr('style', baseStyle + `
+								color: #721c24;
+								background-color: #f8d7da;
+								border: 1px solid #f5c6cb;
+							`)
+							.text(response.data.message || 'An error occurred. Please try again.');
 					}
+
+					setTimeout(function () {
+						$messageBox.fadeOut(300, function () {
+							$messageBox.attr('style', '').text('').show();
+						});
+					}, 5000);
 				},
 				error: function () {
 					alert('Error saving settings.');
 					$button.val(originalText);
-				},
-				complete: function () {
-					setTimeout(function () {
-						$button.prop('disabled', false).val(originalText);
-					}, 2000);
-				},
+				}
 			});
 		},
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -5818,7 +5818,7 @@ table.wp-list-table {
 			min-height: unset;
 			vertical-align: middle;
 			margin-bottom: 6px;
-			
+
 			&:hover {
 				border-color: #0a4b78;
 			}
@@ -11343,7 +11343,7 @@ body {
 				line-height: 150%;
 				min-height: 38px;
 				transition: all 0.3s ease-in-out;
-				
+
 				&:disabled {
 					pointer-events: none;
 				}
@@ -11650,4 +11650,33 @@ button#show-settings-link {
 .evf-disable-row {
 	pointer-events: none;
 	opacity: 0.5;
+}
+
+.everest-forms-clean-talk-message-outer-wrapper{
+	margin-top: 16px;
+	margin-bottom: 6px;
+	padding: 10px 11px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 13px;
+
+	&.everest-forms-clean-talk-empty-state{
+		background: #FFFAF5;
+		border-left: 3px solid #EE9936;
+	}
+
+	&.everest-forms-clean-talk-invalid-state {
+		background: #FFF4F4;
+		border-left: 3px solid #F25656;
+	}
+
+	&.everest-forms-clean-talk-success-state {
+		background: #F5FFF4;
+		border-left: 3px solid #4CC741;
+	}
+
+	.everest-forms-clean-talk-icon-box{
+		margin-top: 5px;
+	}
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 
 = 3.2.2     	- 20-05-2025
+* Enhance 		- Validate clean talk access key on save.
 * Fix 			- Form templates not loading.
 
 = 3.2.1     	- 19-05-2025

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -2046,13 +2046,53 @@ class EVF_AJAX {
 			'everest_forms_recaptcha_cleantalk_access_key',
 		);
 
+		$is_rest_api_method = false;
 		foreach ( $form_data as $data ) {
 			if ( empty( $data['name'] ) ) {
 				continue;
 			}
 
 			if ( in_array( $data['name'], $options_list ) ) {
+				if ( 'everest_forms_clean_talk_methods' === $data['name'] && 'rest_api' === $data['value'] ) {
+					$is_rest_api_method = true;
+				}
+
 				$value = isset( $data['value'] ) ? sanitize_text_field( wp_unslash( $data['value'] ) ) : '';
+
+				if ( $is_rest_api_method && 'everest_forms_recaptcha_cleantalk_access_key' === $data['name'] ) {
+					if ( empty( $value ) ) {
+						wp_send_json_error( array( 'message' => __( 'Please enter the CleanTalk access key.', 'everest-forms' ) ) );
+					}else{
+						$clean_talk_request = array(
+							'method_name' => 'notice_paid_till',
+							'auth_key'    => $value,
+						);
+						$response = wp_remote_post(
+							'https://api.cleantalk.org/',
+							array(
+								'body'    => \http_build_query( $clean_talk_request, true ),
+								'headers' => array(
+									'Content-Type' => 'application/x-www-form-urlencoded',
+								),
+							)
+						);
+						$response = json_decode( wp_remote_retrieve_body( $response ) );
+						if ($response->data->moderate == 1 && $response->data->valid == 1 && $response->data->product_id == 1) {
+							update_option( $data['name'], $value );
+							wp_send_json_success(
+								array(
+									'message' => __( 'Settings saved successfully', 'everest-forms' ),
+								)
+							);
+						} else {
+							wp_send_json_error(
+								array(
+									'message' => __( 'Invalid CleanTalk access key.', 'everest-forms' ),
+								)
+							);
+						}
+					}
+				}
 				update_option( $data['name'], $value );
 			}
 		}

--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -2052,17 +2052,37 @@ class EVF_AJAX {
 				continue;
 			}
 
+			$output = '';
+			$output .= '<div class="everest-forms-clean-talk-message-outer-wrapper">';
+
 			if ( in_array( $data['name'], $options_list ) ) {
-				if ( 'everest_forms_clean_talk_methods' === $data['name'] && 'rest_api' === $data['value'] ) {
+				if ('everest_forms_clean_talk_methods' === $data['name'] && 'rest_api' === $data['value']) {
 					$is_rest_api_method = true;
 				}
 
-				$value = isset( $data['value'] ) ? sanitize_text_field( wp_unslash( $data['value'] ) ) : '';
+				$value = isset( $data['value'] ) ? sanitize_text_field( wp_unslash($data['value'] ) ) : '';
 
 				if ( $is_rest_api_method && 'everest_forms_recaptcha_cleantalk_access_key' === $data['name'] ) {
-					if ( empty( $value ) ) {
-						wp_send_json_error( array( 'message' => __( 'Please enter the CleanTalk access key.', 'everest-forms' ) ) );
-					}else{
+					if (empty($value)) {
+						$output .= '<span class="everest-forms-clean-talk-icon-box">
+							<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<g clip-path="url(#clip0_4735_4306)">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M7.99996 2.00008C4.68625 2.00008 1.99996 4.68637 1.99996 8.00008C1.99996 11.3138 4.68625 14.0001 7.99996 14.0001C11.3137 14.0001 14 11.3138 14 8.00008C14 4.68637 11.3137 2.00008 7.99996 2.00008ZM0.666626 8.00008C0.666626 3.94999 3.94987 0.666748 7.99996 0.666748C12.05 0.666748 15.3333 3.94999 15.3333 8.00008C15.3333 12.0502 12.05 15.3334 7.99996 15.3334C3.94987 15.3334 0.666626 12.0502 0.666626 8.00008ZM7.99996 7.33342C8.36815 7.33342 8.66663 7.63189 8.66663 8.00008V10.6667C8.66663 11.0349 8.36815 11.3334 7.99996 11.3334C7.63177 11.3334 7.33329 11.0349 7.33329 10.6667V8.00008C7.33329 7.63189 7.63177 7.33342 7.99996 7.33342ZM7.99996 4.66675C7.63177 4.66675 7.33329 4.96523 7.33329 5.33342C7.33329 5.7016 7.63177 6.00008 7.99996 6.00008H8.00663C8.37482 6.00008 8.67329 5.7016 8.67329 5.33342C8.67329 4.96523 8.37482 4.66675 8.00663 4.66675H7.99996Z" fill="#EE9936"/>
+							</g>
+							<defs>
+							<clipPath id="clip0_4735_4306">
+							<rect width="16" height="16" fill="white"/>
+							</clipPath>
+							</defs>
+							</svg>
+						</span>';
+						$output .= '<span class="everest-forms-clean-talk-message-box">Please enter the CleanTalk access key.</span>';
+						$output .= '</div>';
+						wp_send_json_error(array(
+							'error' => 'empty',
+							'html'	 => $output,
+						));
+					} else {
 						$clean_talk_request = array(
 							'method_name' => 'notice_paid_till',
 							'auth_key'    => $value,
@@ -2070,24 +2090,42 @@ class EVF_AJAX {
 						$response = wp_remote_post(
 							'https://api.cleantalk.org/',
 							array(
-								'body'    => \http_build_query( $clean_talk_request, true ),
+								'body'    => \http_build_query($clean_talk_request, true),
 								'headers' => array(
 									'Content-Type' => 'application/x-www-form-urlencoded',
 								),
 							)
 						);
-						$response = json_decode( wp_remote_retrieve_body( $response ) );
-						if ($response->data->moderate == 1 && $response->data->valid == 1 && $response->data->product_id == 1) {
+						$response = json_decode(wp_remote_retrieve_body( $response ) );
+						if ( $response->data->moderate == 1 && $response->data->valid == 1 && $response->data->product_id == 1 ) {
 							update_option( $data['name'], $value );
+
+							$output .= '<span class="everest-forms-clean-talk-icon-box">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<path d="M13.3333 4L5.99996 11.3333L2.66663 8" stroke="#4CC741" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>';
+							$output .= '<span class="everest-forms-clean-talk-message-box">Settings saved successfully.</span>';
+							$output .= '</div>';
+
 							wp_send_json_success(
 								array(
-									'message' => __( 'Settings saved successfully', 'everest-forms' ),
+									'html' => $output
 								)
 							);
 						} else {
+							$output .= '<span class="everest-forms-clean-talk-icon-box">
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<path d="M12 4L4 12" stroke="#F25656" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+								<path d="M4 4L12 12" stroke="#F25656" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>';
+							$output .= '<span class="everest-forms-clean-talk-message-box">Invalid CleanTalk access key.</span>';
+							$output .= '</div>';
 							wp_send_json_error(
 								array(
-									'message' => __( 'Invalid CleanTalk access key.', 'everest-forms' ),
+									'error' => 'invalid',
+									'html' => $output
 								)
 							);
 						}
@@ -2097,9 +2135,17 @@ class EVF_AJAX {
 			}
 		}
 
+		$output .= '<span class="everest-forms-clean-talk-icon-box">
+					<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M13.3333 4L5.99996 11.3333L2.66663 8" stroke="#4CC741" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+					</svg>
+		</span>';
+		$output .= '<span class="everest-forms-clean-talk-message-box">Settings saved successfully.</span>';
+		$output .= '</div>';
 		wp_send_json_success(
 			array(
 				'message' => __( 'Settings saved successfully', 'everest-forms' ),
+				'html'    => $output
 			)
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -344,6 +344,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 == Changelog ==
 
 = 3.2.2     	- 20-05-2025
+* Enhance 		- Validate clean talk access key on save.
 * Fix 			- Form templates not loading.
 
 = 3.2.1     	- 19-05-2025


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR prevent saving if cleantalk access key is not valid.

### How to test the changes in this Pull Request:

1. Goto Everest Forms > Global Settings > Integrations > Cleantalk.
2. Try to save wrong access key.
3. Check whether it is stoping saving the wrong access key.
4. Verify it.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Validate clean talk access key on save to prevent invalid key behavior.
