### PR TITLE
Fix - Incorrect asterick display when moving fields

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2835,6 +2835,9 @@
 					EVFPanelBuilder.checkEmptyGrid();
 				},
 				over: function( event, ui ) {
+					if ( ! ui.item.hasClass('required') ) {
+						ui.item.find( '.required' ).remove();
+					}
 					$( '.evf-admin-grid' ).addClass( 'evf-hover' );
 					$( event.target ).addClass( 'evf-item-hover' );
 					$( event.target ).closest( '.evf-admin-row' ).addClass( 'evf-hover' );
@@ -2849,6 +2852,12 @@
 					$(document).trigger('evf_sort_update_complete',{event: event,ui:  ui});
 				},
 				stop: function( event, ui ) {
+					if ( !ui.item.hasClass( 'required' ) ) {
+						const labelTitle = ui.item.find('.label-title');
+						if (labelTitle.length > 0) {
+							labelTitle.append('<span class="required">*</span>');
+						}
+					}
 					ui.item.removeAttr( 'style' );
 					EVFPanelBuilder.checkEmptyGrid();
 				}

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.2.3     	- 05-06-2025
 * Tweak 		- Form fields smart tag options for default value in form fields.
+* Fix 			- Incorrect asterisk display when moving fields.
 * Fix 			- Selection of option while clicking on label for image option.
 
 = 3.2.2     	- 20-05-2025

--- a/readme.txt
+++ b/readme.txt
@@ -345,6 +345,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 = 3.2.3     	- 05-06-2025
 * Tweak 		- Form fields smart tag options for default value in form fields.
+* Fix 			- Incorrect asterisk display when moving fields.
 * Fix 			- Selection of option while clicking on label for image option.
 
 = 3.2.2     	- 20-05-2025


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fix the issue of displaying asterick while moving the fields in form builder.

### How to test the changes in this Pull Request:

1. Move non required fields in form builder.
2. Check whether issue has been resolved or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Incorrect asterick display when moving fields.
