### PR TITLE
Fix - Custom template for style customizer not saving style.

### DIFF
--- a/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
+++ b/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
@@ -170,10 +170,14 @@ class EVF_Style_Customizer_API {
 		// Register a customize section type.
 		$wp_customize->register_section_type( 'EVF_Customize_Templates_Section' );
 
-		$form_data       = EVF()->form->get( $this->form_id, array( 'content_only' => true ) );
-		$template_id     = 'everest_forms_styles[' . $this->form_id . '][template]';
-		$templates_list  = self::get_templates_list();
-		$active_template = isset( $templates_list[ $form_data['settings']['layout_class'] ] ) ? $templates_list[ $form_data['settings']['layout_class'] ] : 'Default Template';
+		$form_data             = EVF()->form->get( $this->form_id, array( 'content_only' => true ) );
+		$template_id           = 'everest_forms_styles[' . $this->form_id . '][template]';
+		$templates_list        = self::get_templates_list();
+		$templates_styles      = get_option( 'everest_forms_styles', array() );
+		$current_form_id       = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
+		$current_template_name = isset( $templates_styles[ $current_form_id ]['template'] ) ? $templates_styles[ $current_form_id ]['template'] : 'Default Template';
+
+		$active_template = isset( $templates_styles[ $current_form_id ]['template'] ) ? $templates_styles[ $current_form_id ]['template'] : 'Default Template';
 
 		$this->add_customize_setting(
 			$wp_customize,
@@ -247,14 +251,14 @@ class EVF_Style_Customizer_API {
 			} else {
 				if ( ! $stored_styles || ! is_array( $stored_styles ) ) {
 					update_option( 'evf_style_templates', $default_styles_raw );
-				} else {
-					foreach ( $default_styles as $key => $value ) {
-						if ( ! isset( $stored_styles[ $key ] ) ) {
-							$stored_styles[ $key ] = $value;
-						}
+			} else {
+				foreach ( $default_styles as $key => $value ) {
+					if ( ! isset( $stored_styles[ $key ] ) ) {
+						$stored_styles[ $key ] = $value;
 					}
+				}
 
-					update_option( 'evf_style_templates', json_encode( $stored_styles ) );
+				update_option( 'evf_style_templates', json_encode( $stored_styles ) );
 				}
 			}
 		}
@@ -766,7 +770,9 @@ class EVF_Style_Customizer_API {
 	 * Update form layout class data.
 	 */
 	public function update_form_data() {
-		$styles    = get_option( 'everest_forms_styles', array() );
+		$styles   = get_option( 'everest_forms_styles', array() );
+		$template = get_option( 'evf_style_templates', array() );
+
 		$form_data = EVF()->form->get( $this->form_id, array( 'content_only' => true ) );
 
 		if ( isset( $form_data['settings']['layout_class'], $styles[ $this->form_id ]['template'] ) ) {

--- a/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
+++ b/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
@@ -259,8 +259,8 @@ class EVF_Style_Customizer_API {
 				}
 
 				update_option( 'evf_style_templates', json_encode( $stored_styles ) );
-				}
 			}
+		}
 		}
 
 		return apply_filters( 'evf_style_templates', json_decode( $styles ) );
@@ -621,9 +621,21 @@ class EVF_Style_Customizer_API {
 			unset( $active_template_customized_data['template'] );
 			$template_data         = isset( $templates_settings[ $active_template_id ]['data'] ) ? $templates_settings[ $active_template_id ]['data'] : array();
 			$updated_template_data = array_merge( $template_data, $active_template_customized_data );
-
-			$templates_settings[ $active_template_id ]['data'] = $updated_template_data;
 		}
+
+		$customized_template_data  = $active_template_customized_data;
+		$customized_template_color = isset( $customized_template_data['color_palette'][ $matched_color_key ] ) ? $customized_template_data['color_palette'][ $matched_color_key ] : array();
+		unset( $customized_template_data['color_palette'] );
+		$customized_template_data['form_container']['background_color']            = $customized_template_color['form_background'];
+		$customized_template_data['field_styles']['field_styles_background_color'] = $customized_template_color['field_background'];
+		$customized_template_data['typography']['field_labels_font_color']         = $customized_template_color['field_label'];
+		$customized_template_data['typography']['field_sublabels_font_color']      = $customized_template_color['field_sublabel'];
+		$customized_template_data['typography']['button_font_color']               = $customized_template_color['button_text'];
+		$customized_template_data['typography']['button_background_color']         = $customized_template_color['button_background'];
+
+		$templates_settings[ $active_template_id ]['data'] = $customized_template_data;
+
+		update_option( 'evf_style_templates', $templates_settings );
 
 		if ( $matched_color_key !== null && isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) {
 			$customized_data[ $form_id ]['color_palette'] = array(

--- a/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
+++ b/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
@@ -274,7 +274,9 @@ class EVF_Style_Customizer_API {
 		$templates_list = array();
 
 		foreach ( $templates as $template_slug => $template ) {
-			$templates_list[ $template_slug ] = $template->name;
+			if ( ! empty( $template->name ) ) {
+				$templates_list[ $template_slug ] = $template->name;
+			}
 		}
 
 		return $templates_list;
@@ -607,6 +609,8 @@ class EVF_Style_Customizer_API {
 				$matched_color_key = $matches[2];
 				$form_id           = $matches[1];
 				break;
+			} elseif ( preg_match( '/everest_forms_styles\[(\d+)\]/', $key, $matches ) ) {
+				$form_id = $matches[1];
 			}
 		}
 
@@ -624,18 +628,18 @@ class EVF_Style_Customizer_API {
 		}
 
 		$customized_template_data  = $active_template_customized_data;
-		$customized_template_color = isset( $customized_template_data['color_palette'][ $matched_color_key ] ) ? $customized_template_data['color_palette'][ $matched_color_key ] : array();
+		$selected_color            = isset( $customized_template_data['color_palette'] ) ? array_key_last( $customized_template_data['color_palette'] ) : array();
+		$customized_template_color = isset( $customized_template_data['color_palette'][ $selected_color ] ) ? $customized_template_data['color_palette'][ $selected_color ] : array();
 		unset( $customized_template_data['color_palette'] );
-		$customized_template_data['form_container']['background_color']            = $customized_template_color['form_background'];
-		$customized_template_data['field_styles']['field_styles_background_color'] = $customized_template_color['field_background'];
-		$customized_template_data['typography']['field_labels_font_color']         = $customized_template_color['field_label'];
-		$customized_template_data['typography']['field_sublabels_font_color']      = $customized_template_color['field_sublabel'];
-		$customized_template_data['typography']['button_font_color']               = $customized_template_color['button_text'];
-		$customized_template_data['typography']['button_background_color']         = $customized_template_color['button_background'];
+		$customized_template_data['form_container']['background_color']            = isset( $customized_template_color['form_background'] ) ? $customized_template_color['form_background'] : '';
+		$customized_template_data['field_styles']['field_styles_background_color'] = isset( $customized_template_color['field_background'] ) ? $customized_template_color['field_background'] : '';
+		$customized_template_data['typography']['field_labels_font_color']         = isset( $customized_template_color['field_label'] ) ? $customized_template_color['field_label'] : '';
+		$customized_template_data['typography']['field_sublabels_font_color']      = isset( $customized_template_color['field_sublabel'] ) ? $customized_template_color['field_sublabel'] : '';
+		$customized_template_data['typography']['button_font_color']               = isset( $customized_template_color['button_text'] ) ? $customized_template_color['button_text'] : '';
+		$customized_template_data['typography']['button_background_color']         = isset( $customized_template_color['button_background'] ) ? $customized_template_color['button_background'] : '';
 
 		$templates_settings[ $active_template_id ]['data'] = $customized_template_data;
-
-		update_option( 'evf_style_templates', $templates_settings );
+		update_option( 'evf_style_templates', json_encode( $templates_settings ) );
 
 		if ( $matched_color_key !== null && isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) {
 			$customized_data[ $form_id ]['color_palette'] = array(

--- a/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
+++ b/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
@@ -177,7 +177,7 @@ class EVF_Style_Customizer_API {
 		$current_form_id       = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 		$current_template_name = isset( $templates_styles[ $current_form_id ]['template'] ) ? $templates_styles[ $current_form_id ]['template'] : 'Default Template';
 
-		$active_template = isset( $templates_styles[ $current_form_id ]['template'] ) ? $templates_styles[ $current_form_id ]['template'] : 'Default Template';
+		$active_template = isset( $templates_styles[ $current_form_id ]['template'] ) ? $templates_list[ $templates_styles[ $current_form_id ]['template'] ] : 'Default Template';
 
 		$this->add_customize_setting(
 			$wp_customize,
@@ -608,6 +608,21 @@ class EVF_Style_Customizer_API {
 				$form_id           = $matches[1];
 				break;
 			}
+		}
+
+		$templates_styles = get_option( 'everest_forms_styles', array() );
+
+		$template           = get_option( 'evf_style_templates', array() );
+		$templates_settings = json_decode( $template, true );
+
+		if ( ! empty( $form_id ) ) {
+			$active_template_id              = isset( $customized_data[ $form_id ]['template'] ) ? $customized_data[ $form_id ]['template'] : 'default';
+			$active_template_customized_data = isset( $customized_data[ $form_id ] ) ? $customized_data[ $form_id ] : array();
+			unset( $active_template_customized_data['template'] );
+			$template_data         = isset( $templates_settings[ $active_template_id ]['data'] ) ? $templates_settings[ $active_template_id ]['data'] : array();
+			$updated_template_data = array_merge( $template_data, $active_template_customized_data );
+
+			$templates_settings[ $active_template_id ]['data'] = $updated_template_data;
 		}
 
 		if ( $matched_color_key !== null && isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, the custom template data was not being saved and it was not used for re-use ability. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a custom template using the color and the fields styling.
2. Use that same template for other form.
3. To use that color palette you need to re-select the color palette again for the form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Custom template for style customizer not saving style.
