### PR TITLE
Fix - HTML entities value for currency is displayed instead of the currency symbol in CSV export of entries.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 3.4.1     	- xx-xx-2025
+* Fix 			- Currency is not parsing correctly in the CSV export.
+
 = 3.4.0     	- 28-07-2025
 * Enhance		- Escaping and sanitization.
 * Dev 			- App on zapier.

--- a/everest-forms.php
+++ b/everest-forms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Everest Forms
  * Plugin URI: https://everestforms.net/
  * Description: Easily create contact form, payment form, conversational form, calculator, multi-step form, registration form, quiz form, survey form etc.
- * Version: 3.4.0
+ * Version: 3.4.1
  * Author: Everest Forms
  * Author URI: https://everestforms.net/
  * Text Domain: everest-forms

--- a/includes/class-everest-forms.php
+++ b/includes/class-everest-forms.php
@@ -23,7 +23,7 @@ final class EverestForms {
 	 *
 	 * @var string
 	 */
-	public $version = '3.4.0';
+	public $version = '3.4.1';
 
 	/**
 	 * The single instance of the class.

--- a/includes/export/class-evf-entry-csv-exporter.php
+++ b/includes/export/class-evf-entry-csv-exporter.php
@@ -457,7 +457,7 @@ class EVF_Entry_CSV_Exporter extends EVF_CSV_Exporter {
 			} else {
 				// It is done to display the currencies symbol instead of its HTML entities values.
 				$clean_value = html_entity_decode(
-					preg_match( '/textarea/', $column_type ) ? sanitize_textarea_field( $value ) : $value,
+					preg_match( '/textarea/', $column_type ) ? sanitize_textarea_field( $value ) : sanitize_text_field( $value ),
 					ENT_QUOTES,
 					'UTF-8'
 				);

--- a/includes/export/class-evf-entry-csv-exporter.php
+++ b/includes/export/class-evf-entry-csv-exporter.php
@@ -455,7 +455,23 @@ class EVF_Entry_CSV_Exporter extends EVF_CSV_Exporter {
 					$row[ $col_row_key ] = $val;
 				}
 			} else {
-				$row[ $column_id ] = apply_filters( 'everest_forms_format_csv_field_data', preg_match( '/textarea/', $column_type ) ? sanitize_textarea_field( $value ) : $value, $raw_value, $column_id, $column_name, $columns, $entry );
+				// It is done to display the currencies symbol instead of its HTML entities values.
+				$clean_value = html_entity_decode(
+					preg_match( '/textarea/', $column_type ) ? sanitize_textarea_field( $value ) : $value,
+					ENT_QUOTES,
+					'UTF-8'
+				);
+
+				$row[ $column_id ] = apply_filters(
+					'everest_forms_format_csv_field_data',
+					$clean_value,
+					$raw_value,
+					$column_id,
+					$column_name,
+					$columns,
+					$entry
+				);
+
 			}
 			if ( empty( $this->request_data ) ) {
 				$row['status'] = (

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: contact form, custom form, form builder, forms, survey
 Requires at least: 5.5
 Tested up to: 6.8.2
 Requires PHP: 7.2
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -342,6 +342,9 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/eve
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/f788d7f0-ea8a-4fd5-bcae-81a5d09a476c)
 
 == Changelog ==
+
+= 3.4.1     	- xx-xx-2025
+* Fix 			- Currency is not parsing correctly in the CSV export.
 
 = 3.4.0     	- 28-07-2025
 * Enhance		- Escaping and sanitization.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While exporting the form entries having the payment field and using the payment currencies, the encoded values was displayed in CSv instead of the currency. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form using the payment fields
2. Perform the entry and export the form's entry
3. Check whether the currency symbol is exported or not in the CSV file.
4. You can use this form for your reference: 
[evf-export-forms-2025-08-14_12_56_38_(1).json](https://github.com/user-attachments/files/21829213/evf-export-forms-2025-08-14_12_56_38_.1.json)


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - HTML entities value for currency is displayed instead of the currency symbol in CSV export of entries.
