### PR TITLE
Fix - Style customizer not saving font size if color palette not chosen

### DIFF
--- a/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
+++ b/addons/StyleCustomizer/includes/class-evf-style-customizer-api.php
@@ -247,16 +247,16 @@ class EVF_Style_Customizer_API {
 			} else {
 				if ( ! $stored_styles || ! is_array( $stored_styles ) ) {
 					update_option( 'evf_style_templates', $default_styles_raw );
-				} else {
-					foreach ( $default_styles as $key => $value ) {
-						if ( ! isset( $stored_styles[ $key ] ) ) {
-							$stored_styles[ $key ] = $value;
-						}
+			} else {
+				foreach ( $default_styles as $key => $value ) {
+					if ( ! isset( $stored_styles[ $key ] ) ) {
+						$stored_styles[ $key ] = $value;
 					}
-
-					update_option( 'evf_style_templates', json_encode( $stored_styles ) );
 				}
+
+				update_option( 'evf_style_templates', json_encode( $stored_styles ) );
 			}
+		}
 		}
 
 		return apply_filters( 'evf_style_templates', json_decode( $styles ) );
@@ -603,17 +603,45 @@ class EVF_Style_Customizer_API {
 				$matched_color_key = $matches[2];
 				$form_id           = $matches[1];
 				break;
+			} elseif ( preg_match( '/everest_forms_styles\[(\d+)\]/', $key, $matches ) ) {
+				$form_id = $matches[1];
 			}
 		}
 
-		if ( $matched_color_key !== null && isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) {
-			$customized_data[ $form_id ]['color_palette'] = array(
-				$matched_color_key => $customized_data[ $form_id ]['color_palette'][ $matched_color_key ],
-			);
+		$existing_color_palette = isset( $customized_data[ $form_id ]['color_palette'] ) ? $customized_data[ $form_id ]['color_palette'] : array();
+
+		if ( ( $matched_color_key !== null && isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) || ! empty( $existing_color_palette ) ) {
+
+			$new_palette = array();
+
+			if ( isset( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) && ! empty( $customized_data[ $form_id ]['color_palette'][ $matched_color_key ] ) ) {
+				$new_palette[ $matched_color_key ] = $customized_data[ $form_id ]['color_palette'][ $matched_color_key ];
+			}
+
+			$new_palette_status = ! empty( $new_palette ) ? 1 : 0;
+
+			switch ( $new_palette_status ) {
+				case 1:
+					// Use the new palette
+					$customized_data[ $form_id ]['color_palette'] = $new_palette;
+					break;
+
+				case 0:
+				default:
+					$last_color_palette = array_key_last( $existing_color_palette );
+					if ( $last_color_palette !== null ) {
+						$customized_data[ $form_id ]['color_palette'][ $last_color_palette ] = $existing_color_palette[ $last_color_palette ];
+					}
+					break;
+			}
+
+			if ( isset( $customized_data[''] ) ) {
+				unset( $customized_data[''] );
+			}
 			update_option( 'everest_forms_styles', $customized_data );
 		}
 
-		return $response;
+			return $response;
 	}
 
 

--- a/addons/StyleCustomizer/includes/views/scss.php
+++ b/addons/StyleCustomizer/includes/views/scss.php
@@ -140,13 +140,13 @@ $container__border_color: <?php echo evf_clean( $values['form_container']['borde
 
 
 //Field Labels Variables.
-$field_label_font_color : <?php echo isset( $values['color_palette'][ $palette_key ]['field_label'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['field_label'] ) : ''; ?>;
+$field_label_font_color : <?php echo isset( $values['color_palette'][ $palette_key ]['field_label'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['field_label'] ) : '#383838'; ?>;
 $field_label_font_size: <?php echo evf_clean( $values['typography']['field_labels_font_size'] ); ?>;
 $field_label_line_height: <?php echo evf_clean( $values['typography']['field_labels_line_height'] ); ?>;
 $field_label_text_alignment: <?php echo evf_clean( $values['typography']['field_labels_text_alignment'] ); ?>;
 
 // Field Sublabels Variables.
-$field_sublabel_font_color: <?php echo isset( $values['color_palette'][ $palette_key ]['field_sublabel'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['field_sublabel'] ) : ''; ?>;
+$field_sublabel_font_color: <?php echo isset( $values['color_palette'][ $palette_key ]['field_sublabel'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['field_sublabel'] ) : '#383838'; ?>;
 $field_sublabel_font_size: <?php echo evf_clean( $values['typography']['field_sublabels_font_size'] ); ?>;
 $field_sublabel_line_height: <?php echo evf_clean( $values['typography']['field_sublabels_line_height'] ); ?>;
 $field_sublabel_text_alignment: <?php echo evf_clean( $values['typography']['field_sublabels_text_alignment'] ); ?>;
@@ -188,14 +188,14 @@ $section_title_alignment: <?php echo evf_clean( $values['typography']['section_t
 $section_title_line_height: <?php echo evf_clean( $values['typography']['section_title_line_height'] ); ?>;
 
 // Button styles variables.
-$button_font_color: <?php echo isset( $values['color_palette'][ $palette_key ]['button_text'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['button_text'] ) : ''; ?>;
+$button_font_color: <?php echo isset( $values['color_palette'][ $palette_key ]['button_text'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['button_text'] ) : '#ffffff'; ?>;
 $button_hover_font_color: <?php echo evf_clean( $values['typography']['button_hover_font_color'] ); ?>;
 $button_font_size: <?php echo evf_clean( $values['typography']['button_font_size'] ); ?>;
 $button_line_height: <?php echo evf_clean( $values['typography']['button_line_height'] ); ?>;
 $button_border_type: <?php echo evf_clean( $values['button']['border_type'] ); ?>;
 $button_border_color: <?php echo evf_clean( $values['typography']['button_border_color'] ); ?>;
 $button_border_hover_color: <?php echo evf_clean( $values['typography']['button_border_hover_color'] ); ?>;
-$button_background_color: <?php echo isset( $values['color_palette'][ $palette_key ]['button_background'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['button_background'] ) : ''; ?>;
+$button_background_color: <?php echo isset( $values['color_palette'][ $palette_key ]['button_background'] ) ? evf_clean( $values['color_palette'][ $palette_key ]['button_background'] ) : '#7545bb'; ?>;
 $button_hover_background_color: <?php echo evf_clean( $values['typography']['button_hover_background_color'] ); ?>;
 
 // Success Message styles variables.
@@ -302,7 +302,7 @@ $validation_message_border_color: <?php echo evf_clean( $values['validation_mess
 					text-align: $field_label_text_alignment;
 					<?php foreach ( array( 'field_labels_margin', 'field_labels_padding' ) as $separator_type ) : ?>
 						<?php foreach ( $values['typography'][ $separator_type ] as $device => $value ) : ?>
-							<?php if ( in_array( $device, array( 'desktop', 'tablet', 'mobille' ), true ) ) : ?>
+							<?php if ( in_array( $device, array( 'desktop', 'tablet', 'mobile' ), true ) ) : ?>
 								<?php printf( '@include responsive-media(%s, %s, %s);', preg_replace( '/.*_/', '', $separator_type ), $device, evf_sanitize_dimension_unit( $value, 'px' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 							<?php endif; ?>
 						<?php endforeach; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While trying to set the font style without selecting the color palette, the style was not being saved. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Use the style customizer
2. Set font styles and the typography without selecting the color palette
3. Check if the style is being set or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Style customizer not saving font size if color palette not chosen.