### PR TITLE
Fix - entry_id smart tag not working for redirect url in form confirmation

### DIFF
--- a/includes/class-evf-smart-tags.php
+++ b/includes/class-evf-smart-tags.php
@@ -569,7 +569,12 @@ class EVF_Smart_Tags {
 						break;
 
 					case 'entry_id':
-						$content = str_replace( '{' . $other_tag . '}', $entry_id, $content );
+						if ( ! empty( $entry_id ) ) {
+							$content = str_replace( '{' . $other_tag . '}', $entry_id, $content );
+						} else {
+							$form_entry_id = ! empty( $form_data['entry']['id'] ) ? absint( $form_data['entry']['id'] ) : '';
+							$content       = str_replace( '{' . $other_tag . '}', $form_entry_id, $content );
+						}
 						break;
 
 					default:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When using the Confirmation Settings with Redirect to Custom Page and enabling Append Query String, the {entry_id} placeholder does not populate correctly. Only {form_id} works as expected.

Closes # .

### How to test the changes in this Pull Request:

1. Go to form settings → Confirmation Settings.
2. Select Redirect to Custom Page.
3. Enable Append Query String.
4. Enter form_id={form_id}&entry_id={entry_id} as the query string.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - entry_id smart tag not working for redirect url in form confirmation.