### PR TITLE
Dev - Changes rest api into sdk and adjusted changes according to the cleantalk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
   "require": {
     "php": ">=5.6.20",
     "composer/installers": "2.0.1",
-    "scssphp/scssphp": "^1.13.0"
+    "scssphp/scssphp": "^1.13.0",
+    "cleantalk/php-antispam": "^4.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^5 || ^7",

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -8,6 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use CleanTalk\CleantalkAntispam;
 use Cleantalk\Antispam\CleantalkRequest;
 use EverestForms\Helpers\FormHelper;
 
@@ -1967,7 +1968,16 @@ class EVF_Form_Task {
 			return true;
 		}
 
-		$clean_talk_passed = $response->allow == 1 && $response->spam == 0 && $response->account_status == 1;
+		$email_field        = isset( $entry_data['sender_email'] ) ? $entry_data['sender_email'] : '';
+		$cleantalk_antispam = new CleantalkAntispam( $access_key, $email_field );
+		$api_result         = $cleantalk_antispam->handle();
+		if ( empty( $api_result ) ) {
+			return true;
+		}
+		$api_result = $cleantalk_antispam->handle();
+		$cleantalk_antispam->setEventTokenEnabled( 1 );
+
+		$clean_talk_passed = $api_result->allow == 1 && $api_result->spam == 0 && $api_result->account_status == 1;
 
 		if ( ! $clean_talk_passed ) {
 			$marked_as_spam = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, the REST API was used instead of the CleanTalk SDK, which made it difficult to incorporate the changes suggested by CleanTalk. This PR replaces the REST API with the SDK and updates the code according to the recommendations provided by the CleanTalk team.

Closes # .

### How to test the changes in this Pull Request:

1. Use the Cleantalk integration in form and check if it is working as expected or not. You can refer to this docs:[Eveerst Forms Cleantalk Docs](https://docs.everestforms.net/docs/cleantalk/)


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Changes rest api into sdk and adjusted changes according to the cleantalk.
