### PR TITLE
Fix - Coupon field is available even when coupon add on is disabled

### DIFF
--- a/includes/class-evf-forms-features.php
+++ b/includes/class-evf-forms-features.php
@@ -50,7 +50,6 @@ class EVF_Forms_Features {
 			'EVF_Field_Payment_Quantity',
 			'EVF_Field_Payment_Total',
 			'EVF_Field_Payment_Subtotal',
-			'EVF_Field_Payment_Square',
 			'EVF_Field_Payment_Subscription_Plan',
 			'EVF_Field_Credit_Card',
 			'EVF_Field_Payment_Authorize_Net',
@@ -66,8 +65,15 @@ class EVF_Forms_Features {
 
 		$enabled_features = get_option( 'everest_forms_enabled_features', array() );
 
-		if ( ! empty( $enabled_features ) && in_array( 'everest-forms-coupons', $enabled_features, true ) ) {
-			$pro_fields[] = 'EVF_Field_Payment_Coupon';
+		$feature_map = array(
+			'everest-forms-coupons' => 'EVF_Field_Payment_Coupon',
+			'everest-forms-square'  => 'EVF_Field_Payment_Square',
+		);
+
+		foreach ( $feature_map as $feature => $class ) {
+			if ( in_array( $feature, $enabled_features, true ) ) {
+				$pro_fields[] = $class;
+			}
 		}
 
 		return array_merge( $fields, $pro_fields );

--- a/includes/class-evf-forms-features.php
+++ b/includes/class-evf-forms-features.php
@@ -50,7 +50,6 @@ class EVF_Forms_Features {
 			'EVF_Field_Payment_Quantity',
 			'EVF_Field_Payment_Total',
 			'EVF_Field_Payment_Subtotal',
-			'EVF_Field_Payment_Coupon',
 			'EVF_Field_Payment_Square',
 			'EVF_Field_Payment_Subscription_Plan',
 			'EVF_Field_Credit_Card',
@@ -64,6 +63,12 @@ class EVF_Forms_Features {
 			'EVF_Field_Lookup',
 
 		);
+
+		$enabled_features = get_option( 'everest_forms_enabled_features', array() );
+
+		if ( ! empty( $enabled_features ) && in_array( 'everest-forms-coupons', $enabled_features, true ) ) {
+			$pro_fields[] = 'EVF_Field_Payment_Coupon';
+		}
 
 		return array_merge( $fields, $pro_fields );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, Coupon fields are visible when module is disabled. This PR fix this issue.

### How to test the changes in this Pull Request:

1. Add coupon fields on form.
2. Now disable the coupon module.
3. Preview the form. Verify issue has been resolved or not.

Dependency PR: [Pro](https://github.com/wpeverest/everest-forms-pro/pull/1107)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Coupon field is available even when coupon add on is disabled.
