### PR TITLE
Fix - Bulk action notice issue in entry table

### DIFF
--- a/assets/js/frontend/everest-forms-file-upload.js
+++ b/assets/js/frontend/everest-forms-file-upload.js
@@ -232,6 +232,8 @@
 			dz.loading--;
 			toggleSubmit( dz );
 			updateInputValue( dz );
+			var $td = $( dz.element ).closest('.evf-field').closest('td');
+			$td.find('.evf-error').remove();
 		};
 	}
 

--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -1001,6 +1001,14 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 			}
 			$sendback = remove_query_arg( array( 'action', 'action2' ), $sendback );
 
+			$sendback = add_query_arg(
+				array(
+					'bulk_action' => $doaction,
+					'bulk_count'  => $count,
+				),
+				$sendback
+			);
+
 			wp_safe_redirect( $sendback );
 			exit();
 		} elseif ( ! empty( $_REQUEST['_wp_http_referer'] ) && isset( $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/admin/class-evf-admin-entries.php
+++ b/includes/admin/class-evf-admin-entries.php
@@ -118,7 +118,42 @@ class EVF_Admin_Entries {
 		?>
 
 		<div id="everest-forms-entries-list" class="wrap">
-			<?php settings_errors(); ?>
+			<?php
+			if ( isset( $_GET['bulk_action'], $_GET['bulk_count'] ) ) {
+
+				$action = sanitize_key( $_GET['bulk_action'] );
+				$count  = intval( $_GET['bulk_count'] );
+
+				$messages = array(
+					'star'    => __( '%d entry starred.', 'everest-forms' ),
+					'unstar'  => __( '%d entry unstarred.', 'everest-forms' ),
+					'read'    => __( '%d entry marked as read.', 'everest-forms' ),
+					'unread'  => __( '%d entry marked as unread.', 'everest-forms' ),
+					'trash'   => __( '%d entry moved to Trash.', 'everest-forms' ),
+					'untrash' => __( '%d entry restored from Trash.', 'everest-forms' ),
+					'delete'  => __( '%d entry permanently deleted.', 'everest-forms' ),
+					'spam'    => __( '%d entry marked as spam.', 'everest-forms' ),
+					'unspam'  => __( '%d entry removed from spam.', 'everest-forms' ),
+					'approved'=> __( '%d entry approved.', 'everest-forms' ),
+					'denied'  => __( '%d entry denied.', 'everest-forms' ),
+				);
+
+				if ( isset( $messages[ $action ] ) ) {
+
+					$message = sprintf(
+						_n(
+							$messages[$action],
+							str_replace( 'entry', 'entries', $messages[ $action ] ),
+							$count,
+							'everest-forms'
+						),
+						$count
+					);
+
+					echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $message ) . '</p></div>';
+				}
+			}
+			?>
 			<div class="evf-entries-tab-wrapper">
 				<div class="evf-entries-tab-header">
 					<div class="evf-entries-tab-header-title">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously, no notification are shown on entry approval and denial.

### How to test the changes in this Pull Request:

1. Try bulk action on entry table.
2. Verify notification is working or not.

Note: Dependency PR: [Pro](https://github.com/wpeverest/everest-forms-pro/pull/1110)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Bulk action notice issue in entry table