### PR TITLE
Fix - License hit issue.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix         - Blank tags appearing in Form Builder settings.
 * Fix         - Switch filter redirection issue.
 * Fix         - Role and permission issue when creating a form.
+* Fix         - License API issue causing excessive requests.
 
 
 = 3.4.3       - 19-02-2026

--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -1622,43 +1622,73 @@ function evf_get_required_label()
  * @since  1.2.0
  * @return bool|string Plan on success, false on failure.
  */
-function evf_get_license_plan()
-{
-	$license_key = get_option('everest-forms-pro_license_key');
+function evf_get_license_plan() {
+	if (
+		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'DOING_CRON' )   && DOING_CRON   ) ||
+		( defined( 'DOING_AJAX' )   && DOING_AJAX   )
+	) {
+		return evf_handle_license_plan_compatibility(
+			get_option( 'evf_saved_license_plan', 'personal' )
+		);
+	}
 
-	if (! function_exists('is_plugin_active')) {
+	$license_key = get_option( 'everest-forms-pro_license_key' );
+
+	if ( ! function_exists( 'is_plugin_active' ) ) {
 		include_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
-	if ($license_key && is_plugin_active('everest-forms-pro/everest-forms-pro.php')) {
-		$license_data = get_transient('evf_pro_license_plan');
-		if (false === $license_data) {
-			$license_response = EVF_Updater_Key_API::check(array('license' => $license_key));
-
-			if (! $license_response) {
-				$license_plan = get_option('evf_saved_license_plan', 'unknown');
-				return evf_handle_license_plan_compatibility($license_plan);
-			}
-
-			$license_data     = json_decode($license_response);
-
-			if (! empty($license_data->item_name)) {
-				$license_data->item_plan = strtolower($license_data->item_name);
-				$license_data->item_plan = str_replace(
-					array('everest forms', 'lifetime', '-lifetime'),
-					'',
-					$license_data->item_plan
-				);
-				$license_data->item_plan = trim($license_data->item_plan);
-				update_option('evf_saved_license_plan', $license_data->item_plan);
-				set_transient('evf_pro_license_plan', $license_data, WEEK_IN_SECONDS);
-			}
-		}
-		$license_plan = isset($license_data->item_plan) ? $license_data->item_plan : get_option('evf_saved_license_plan', 'unknown');
-		return evf_handle_license_plan_compatibility($license_plan);
+	if ( ! $license_key || ! is_plugin_active( 'everest-forms-pro/everest-forms-pro.php' ) ) {
+		return false;
 	}
 
-	return false;
+	$license_data = get_transient( 'evf_pro_license_plan' );
+
+	if ( false !== $license_data ) {
+		$license_plan = isset( $license_data->item_plan )
+			? $license_data->item_plan
+			: get_option( 'evf_saved_license_plan', 'personal' );
+
+		return evf_handle_license_plan_compatibility( $license_plan );
+	}
+
+	$license_response = EVF_Updater_Key_API::check( array( 'license' => $license_key ) );
+
+	if ( ! $license_response ) {
+		$saved_plan = get_option( 'evf_saved_license_plan', 'personal' );
+		set_transient( 'evf_pro_license_plan', (object) array( 'item_plan' => $saved_plan ), HOUR_IN_SECONDS );
+
+		return evf_handle_license_plan_compatibility( $saved_plan );
+	}
+
+	$license_data = json_decode( $license_response );
+
+	if ( empty( $license_data ) || ! is_object( $license_data ) ) {
+		$saved_plan = get_option( 'evf_saved_license_plan', 'personal' );
+		set_transient( 'evf_pro_license_plan', (object) array( 'item_plan' => $saved_plan ), HOUR_IN_SECONDS );
+
+		return evf_handle_license_plan_compatibility( $saved_plan );
+	}
+
+	if ( ! empty( $license_data->item_name ) ) {
+		$item_plan = trim( str_replace(
+			array( 'everest forms', 'lifetime', '-lifetime' ),
+			'',
+			strtolower( $license_data->item_name )
+		) );
+
+		$license_data->item_plan = $item_plan;
+
+		update_option( 'evf_saved_license_plan', $item_plan );
+		set_transient( 'evf_pro_license_plan', $license_data, WEEK_IN_SECONDS );
+	}
+
+	$license_plan = isset( $license_data->item_plan )
+		? $license_data->item_plan
+		: get_option( 'evf_saved_license_plan', 'personal' );
+
+	return evf_handle_license_plan_compatibility( $license_plan );
 }
 
 add_action('admin_init', 'evf_handle_force_update');
@@ -5673,6 +5703,3 @@ function evf_form_confirmation_backward_compatibility($form_data)
 
 	return $form_data;
 }
-
-
-


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms-pro/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes a critical issue where the license server was being flooded with 20-30+ API calls on every wp-admin page load across customer sites, causing the server to go down.

Centralized all addon update checks into a single check_all_addons_update() method in class-evf-plugin-updater.php
Added a 24-hour transient gate and 30-second race condition lock to prevent repeated API calls
Removed individual plugin_updater() method and its admin_init hook from each addon


### How to test the changes in this Pull Request:

1.
2.
3.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.