### PR TITLE
Fix: uploaded PDF/DOC/TXT files not displayed in entries single view

### DIFF
--- a/includes/abstracts/class-evf-form-fields-upload.php
+++ b/includes/abstracts/class-evf-form-fields-upload.php
@@ -35,7 +35,7 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 	 */
 	public function init_hooks() {
 		add_action( 'everest_forms_shortcode_scripts', array( $this, 'load_assets' ) );
-		add_filter( 'everest_forms_html_field_value', array( $this, 'html_field_value' ), 10, 4 );
+		add_filter( 'everest_forms_html_field_value', array( $this, 'html_field_value' ), 10, 5 );
 		add_filter( 'everest_forms_plaintext_field_value', array( $this, 'plaintext_field_value' ), 10, 4 );
 		add_filter( 'everest_forms_field_exporter_' . $this->type, array( $this, 'field_exporter' ) );
 		add_filter( 'everest_forms_email_file_attachments', array( $this, 'send_file_as_email_attachment' ), 99, 6 );
@@ -777,7 +777,7 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 	 * @param  string $context   Value display context.
 	 * @return string $val       Html Value.
 	 */
-	public function html_field_value( $val, $field_val, $form_data = array(), $context = '' ) {
+	public function html_field_value( $val, $field_val, $form_data = array(), $context = '', $field_meta_key = '' ) {
 		$meta_key = '';
 		$entry_id = false;
 		$uploads  = wp_upload_dir();
@@ -843,7 +843,7 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 
 		if ( isset( $_GET['view-entry'] ) && 'entry-single' === $context ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$entry_id = absint( $_GET['view-entry'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			$meta_key = array_search( $val, $form_data, true );
+			$meta_key = ! empty( $field_meta_key ) ? evf_clean( $field_meta_key ) : array_search( $val, $form_data, true );
 		} elseif ( isset( $_GET['edit-entry'], $field_val['meta_key'] ) && 'entry-single' === $context ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$entry_id = absint( $_GET['edit-entry'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			$meta_key = evf_clean( $field_val['meta_key'] );
@@ -873,6 +873,7 @@ abstract class EVF_Form_Fields_Upload extends EVF_Form_Fields {
 					foreach ( $field['value_raw'] as $file ) {
 						if ( empty( $file['value'] ) || empty( $file['file_original'] ) ) {
 							$output[ $meta_key ] = '';
+							continue;
 						}
 
 						$file_url      = esc_url( $file['value'] );

--- a/includes/admin/views/html-admin-page-entries-view.php
+++ b/includes/admin/views/html-admin-page-entries-view.php
@@ -162,7 +162,7 @@ if ( false !== $entry_index ) {
 								$meta_value = $meta_value['value'];
 							}
 
-							$field_value     = apply_filters( 'everest_forms_html_field_value', $meta_value, $entry_meta[ $meta_key ], $entry_meta, 'entry-single' );
+							$field_value     = apply_filters( 'everest_forms_html_field_value', $meta_value, $entry_meta[ $meta_key ], $entry_meta, 'entry-single', $meta_key );
 							$is_empty        = is_string( $field_value ) && ( '(empty)' === wp_strip_all_tags( $field_value ) || '' === $field_value );
 							$field_class     = $is_empty ? 'evf-field-empty' : '';
 							$correct_answers = false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug where uploaded files (PDF, DOC, TXT, ZIP, etc.) upload successfully and appear in notification emails, but are not visible in the WordPress admin entry single view.

**Root cause:** The entry-single view template passes `$meta_key` to the `everest_forms_html_field_value` filter but the filter was registered to accept only 4 arguments, so the meta key was never received by the upload class. Without it, `html_field_value()` fell back to `array_search( $val, $form_data, true )` with strict comparison, which silently returned `false` when `esc_html()` had altered the file URL — causing all files to be skipped and the field to render blank.

- Pass `$meta_key` as 5th argument to `everest_forms_html_field_value` filter in the entry-single view template
- Increase `add_filter` accepted args from `4` to `5` in `class-evf-form-fields-upload.php`
- Add `$field_meta_key` as 5th parameter to `html_field_value()` and use it directly for meta key resolution in `entry-single` context
- Add missing `continue` after setting empty `$output[$meta_key]` to prevent a string/array type conflict on subsequent loop iterations

Closes # .

### How to test the changes in this Pull Request:

1. Create a form with a file-upload field and submit an entry with a PDF, DOC, or TXT file
2. Go to WP Admin → Everest Forms → Entries → open the entry single view
3. Verify the uploaded file displays as a clickable link with the filename
4. Verify email notifications still display the file correctly
5. Verify the entry table list view still displays files correctly

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Uploaded files (PDF, DOC, TXT, etc.) not displaying in the entry single view in WP admin due to fragile meta key resolution via strict array_search comparison.