### PR TITLE
Fix: Add authorization checks to prevent unauthenticated form submission

### DIFF
--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -667,7 +667,7 @@ class EVF_AJAX {
 	 * Ajax handler for form submission.
 	 */
 	public static function ajax_form_submission() {
-		// check_ajax_referer( 'everest_forms_ajax_form_submission', 'security' );
+		check_ajax_referer( 'everest_forms_ajax_form_submission', 'security' );
 
 		if ( ! empty( $_POST['everest_forms']['id'] ) ) {
 			$process = evf()->task->ajax_form_submission( evf_sanitize_entry( wp_unslash( $_POST['everest_forms'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -2274,6 +2274,10 @@ class EVF_AJAX {
 	 * @since 3.3.0
 	 */
 	public static function get_form_update_nonce() {
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+			wp_die( __( 'Permission denied.', 'everest-forms' ), 403 );
+		}
+
 		$form_id = isset( $_POST['form_id'] ) ? absint( $_POST['form_id'] ) : 0;
 
 		if ( empty( $form_id ) ) {
@@ -2284,15 +2288,6 @@ class EVF_AJAX {
 
 		if ( empty( $form ) ) {
 			wp_die( __( 'Form not found!', 'everest-forms' ), 403 );
-		}
-
-		// Strict referer verification
-		$referer      = wp_get_referer();
-		$allowed_host = parse_url( home_url(), PHP_URL_HOST );
-		$referer_host = parse_url( $referer, PHP_URL_HOST );
-
-		if ( ! $referer || $referer_host !== $allowed_host ) {
-			wp_die( __( 'Invalid form submission source.', 'everest-forms' ), 403 );
 		}
 
 		wp_send_json_success( wp_create_nonce( 'everest-forms_process_submit' ) );


### PR DESCRIPTION
- Restore check_ajax_referer() in ajax_form_submission() that was commented out, leaving the handler open to unauthenticated requests
- Replace bypassable Referer header check in get_form_update_nonce() with proper is_user_logged_in() + current_user_can() checks to prevent unauthenticated attackers from generating valid nonces

Together these two issues allowed an attack chain: an unauthenticated attacker could request a valid form submission nonce from get_form_update_nonce (only protected by a forgeable Referer header), then use it to submit spam data via ajax_form_submission (which had its nonce check commented out).

### All Submissions:

* [ ] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
