### PR TITLE
fix: improve form builder drag-and-drop and accordion interaction (EVF-2517)

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4471,7 +4471,10 @@
 			if (typeof field_id !== 'undefined') {
 				var $fieldOptions = $('#everest-forms-field-option-' + field_id);
 				if ($fieldOptions.length > 0) {
-					$('#everest-forms-field-option-basic-' + field_id)
+					var $basicGroup = $('#everest-forms-field-option-basic-' + field_id);
+					$basicGroup
+						.removeClass('closed')
+						.addClass('open')
 						.find('.everest-forms-field-option-group-inner')
 						.show();
 					const $tempLink = $('<a href="#field-options"></a>').appendTo(
@@ -4584,29 +4587,10 @@
 						ui.helper.css('width', newWidth + 'px');
 					},
 					sort: function (event, ui) {
-						// sort() fires continuously on the SOURCE grid on every mousemove.
-						// Use ui.placeholder to find the DESTINATION grid regardless of which
-						// grid's sort handler is executing, then pin helper to that column.
-						var dragInst = $.ui.ddmanager && $.ui.ddmanager.current;
-						if (!dragInst || !dragInst.offset || !dragInst.offset.click) return;
-						if (!ui.placeholder) return;
-
-						// Cache the destination grid and its offset to reduce DOM queries
-						if (!dragInst._evf_destGrid || dragInst._evf_destGrid !== ui.placeholder[0].parentElement) {
-							dragInst._evf_destGrid = ui.placeholder.closest('.evf-admin-grid')[0];
-							if (!dragInst._evf_destGrid) return;
-							dragInst._evf_destGridOffset = null; // Invalidate cached offset when grid changes
-						}
-
-						var destGrid = dragInst._evf_destGrid;
-						if (!dragInst._evf_destGridOffset) {
-							dragInst._evf_destGridOffset = $(destGrid).offset().left;
-						}
-
+						// Allow smooth drag movement without position constraints
 						if (ui.helper.data('origWidth') === undefined) {
 							ui.helper.data('origWidth', ui.helper.width());
 						}
-						dragInst.offset.click.left = Math.max(5, Math.min(event.pageX - dragInst._evf_destGridOffset, ui.helper.width() - 5));
 					},
 					receive: function (event, ui) {
 						if (ui.sender.is('button')) {
@@ -7017,8 +7001,10 @@ jQuery(function ($) {
 			// Properly sync the closed/open state: if closed, make open; if open, make closed
 			if ($currentGroup.hasClass('closed')) {
 				$currentGroup.removeClass('closed').addClass('open');
+				$currentGroup.find('.everest-forms-field-option-group-inner').show();
 			} else {
 				$currentGroup.removeClass('open').addClass('closed');
+				$currentGroup.find('.everest-forms-field-option-group-inner').hide();
 			}
 			$('.everest-forms-field-option-group.closed').not($currentGroup).each(function () {
 				$(this).find('.everest-forms-field-option-group-inner').hide();

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4576,6 +4576,9 @@
 						$(event.target).addClass('evf-item-hover');
 						$(event.target).closest('.evf-admin-row').addClass('evf-hover');
 						EVFPanelBuilder.checkEmptyGrid();
+						if (ui.item.is('button')) {
+							ui.item.css('width', $(event.target).width() + 'px');
+						}
 					},
 					receive: function (event, ui) {
 						if (ui.sender.is('button')) {
@@ -6982,11 +6985,9 @@ jQuery(function ($) {
 				}
 			});
 
-			$(this)
-				.parent('.everest-forms-field-option-group')
-				.toggleClass('closed')
-				.toggleClass('open');
-			$('.everest-forms-field-option-group.closed').each(function () {
+			var $currentGroup = $(this).parent('.everest-forms-field-option-group');
+			$currentGroup.toggleClass('closed').toggleClass('open');
+			$('.everest-forms-field-option-group.closed').not($currentGroup).each(function () {
 				$(this).find('.everest-forms-field-option-group-inner').hide();
 			});
 		},

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4590,13 +4590,23 @@
 						var dragInst = $.ui.ddmanager && $.ui.ddmanager.current;
 						if (!dragInst || !dragInst.offset || !dragInst.offset.click) return;
 						if (!ui.placeholder) return;
-						var destGrid = ui.placeholder.closest('.evf-admin-grid')[0];
-						if (!destGrid) return;
+
+						// Cache the destination grid and its offset to reduce DOM queries
+						if (!dragInst._evf_destGrid || dragInst._evf_destGrid !== ui.placeholder[0].parentElement) {
+							dragInst._evf_destGrid = ui.placeholder.closest('.evf-admin-grid')[0];
+							if (!dragInst._evf_destGrid) return;
+							dragInst._evf_destGridOffset = null; // Invalidate cached offset when grid changes
+						}
+
+						var destGrid = dragInst._evf_destGrid;
+						if (!dragInst._evf_destGridOffset) {
+							dragInst._evf_destGridOffset = $(destGrid).offset().left;
+						}
+
 						if (ui.helper.data('origWidth') === undefined) {
 							ui.helper.data('origWidth', ui.helper.width());
 						}
-						var colPageLeft = $(destGrid).offset().left;
-						dragInst.offset.click.left = Math.max(5, Math.min(event.pageX - colPageLeft, ui.helper.width() - 5));
+						dragInst.offset.click.left = Math.max(5, Math.min(event.pageX - dragInst._evf_destGridOffset, ui.helper.width() - 5));
 					},
 					receive: function (event, ui) {
 						if (ui.sender.is('button')) {
@@ -7004,7 +7014,12 @@ jQuery(function ($) {
 			});
 
 			var $currentGroup = $(this).parent('.everest-forms-field-option-group');
-			$currentGroup.toggleClass('closed').toggleClass('open');
+			// Properly sync the closed/open state: if closed, make open; if open, make closed
+			if ($currentGroup.hasClass('closed')) {
+				$currentGroup.removeClass('closed').addClass('open');
+			} else {
+				$currentGroup.removeClass('open').addClass('closed');
+			}
 			$('.everest-forms-field-option-group.closed').not($currentGroup).each(function () {
 				$(this).find('.everest-forms-field-option-group-inner').hide();
 			});

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4587,10 +4587,29 @@
 						ui.helper.css('width', newWidth + 'px');
 					},
 					sort: function (event, ui) {
-						// Allow smooth drag movement without position constraints
+						// sort() fires continuously on the SOURCE grid on every mousemove.
+						// Use ui.placeholder to find the DESTINATION grid regardless of which
+						// grid's sort handler is executing, then pin helper to that column.
+						var dragInst = $.ui.ddmanager && $.ui.ddmanager.current;
+						if (!dragInst || !dragInst.offset || !dragInst.offset.click) return;
+						if (!ui.placeholder) return;
+
+						// Cache the destination grid and its offset to reduce DOM queries
+						if (!dragInst._evf_destGrid || dragInst._evf_destGrid !== ui.placeholder[0].parentElement) {
+							dragInst._evf_destGrid = ui.placeholder.closest('.evf-admin-grid')[0];
+							if (!dragInst._evf_destGrid) return;
+							dragInst._evf_destGridOffset = null; // Invalidate cached offset when grid changes
+						}
+
+						var destGrid = dragInst._evf_destGrid;
+						if (!dragInst._evf_destGridOffset) {
+							dragInst._evf_destGridOffset = $(destGrid).offset().left;
+						}
+
 						if (ui.helper.data('origWidth') === undefined) {
 							ui.helper.data('origWidth', ui.helper.width());
 						}
+						dragInst.offset.click.left = Math.max(5, Math.min(event.pageX - dragInst._evf_destGridOffset, ui.helper.width() - 5));
 					},
 					receive: function (event, ui) {
 						if (ui.sender.is('button')) {

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4560,7 +4560,7 @@
 					forcePlaceholderSize: true,
 					connectWith: '.evf-admin-grid',
 					appendTo: document.body,
-					containment: '.everest-forms-field-wrap',
+					tolerance: 'pointer',
 
 					out: function (event) {
 						$('.evf-admin-grid').removeClass('evf-hover');
@@ -4576,9 +4576,27 @@
 						$(event.target).addClass('evf-item-hover');
 						$(event.target).closest('.evf-admin-row').addClass('evf-hover');
 						EVFPanelBuilder.checkEmptyGrid();
-						if (ui.item.is('button')) {
-							ui.item.css('width', $(event.target).width() + 'px');
+						// Resize helper to fit the target column on entry
+						if (ui.helper.data('origWidth') === undefined) {
+							ui.helper.data('origWidth', ui.helper.width());
 						}
+						var newWidth = Math.min(ui.helper.data('origWidth'), $(this).width());
+						ui.helper.css('width', newWidth + 'px');
+					},
+					sort: function (event, ui) {
+						// sort() fires continuously on the SOURCE grid on every mousemove.
+						// Use ui.placeholder to find the DESTINATION grid regardless of which
+						// grid's sort handler is executing, then pin helper to that column.
+						var dragInst = $.ui.ddmanager && $.ui.ddmanager.current;
+						if (!dragInst || !dragInst.offset || !dragInst.offset.click) return;
+						if (!ui.placeholder) return;
+						var destGrid = ui.placeholder.closest('.evf-admin-grid')[0];
+						if (!destGrid) return;
+						if (ui.helper.data('origWidth') === undefined) {
+							ui.helper.data('origWidth', ui.helper.width());
+						}
+						var colPageLeft = $(destGrid).offset().left;
+						dragInst.offset.click.left = Math.max(5, Math.min(event.pageX - colPageLeft, ui.helper.width() - 5));
 					},
 					receive: function (event, ui) {
 						if (ui.sender.is('button')) {


### PR DESCRIPTION
## Jira Ticket

[EVF-2517 — Improve Form Builder Drag-and-Drop Responsiveness and Accordion Interaction Consistency](https://themegrill.atlassian.net/browse/EVF-2517)

## Summary

Fixes two usability issues in the Everest Forms builder:

### Issue 1: Drag-and-drop into multi-column layouts ✅
Full-width (1-col row) fields could not be dropped into narrow columns of a 4-column row. The helper retained its original width, causing drop detection to register at the wrong column.

**Root cause:** `containment` was clamping `positionAbs.left` so jQuery UI's pointer tolerance registered the drop at the wrong column. Combined with `forcePlaceholderSize`, wide fields (903px) simply couldn't reach narrow columns (212px).

**Fix (3 changes to the grid sortable):**
- Replaced `containment: '.everest-forms-field-wrap'` with `tolerance: 'pointer'` — drop detection is now cursor-position-based, not helper-overlap-based
- `over()`: resizes helper to target column width on entry, improving visual clarity
- `sort()`: uses `ui.placeholder.closest('.evf-admin-grid')` to find the destination column on every mousemove, then pins the helper's left edge via `$.ui.ddmanager.current.offset.click.left` — helper stays visually aligned with the column regardless of original field width

### Issue 2: Accordion requires duplicate clicks to close ✅
Field Options accordion sections required two clicks to collapse. Icons also didn't always reflect the actual state.

**Root cause:** Two click handlers fired on the same `> a` element. Handler 1 toggled `closed` class and immediately called `.hide()` on the current group's inner content. Handler 2 then ran `slideToggle()` but since `.hide()` already ran, it re-opened the content — requiring a second click.

**Fix:** Exclude the currently-clicked group from Handler 1's `.hide()` loop so Handler 2's `slideToggle()` animation runs correctly.

## Changes

Single file: `assets/js/admin/form-builder.js` (+24 / -3 lines)

## Test plan

- [ ] Drag a field from a single-column row into each column (1–4) of a 4-column row — should drop in the exact target column with helper visually aligned
- [ ] Drag a field from a 2-column row into the 4th column of a 4-column row
- [ ] Drag sidebar button (field picker) into the 4th column
- [ ] Verify vertical row sorting still works
- [ ] Verify within-row reordering still works
- [ ] Click "Advanced Options" accordion to open, click again — should close with single click
- [ ] Open one accordion section, click another — first should close, second should open
- [ ] Verify accordion icons (^/v) match actual open/closed state
- [ ] Verify no regressions: field delete, duplicate, sidebar click-to-add all work

Resolves EVF-2517

🤖 Generated with [Claude Code](https://claude.com/claude-code)