### PR TITLE
EVF-2430 fix: prevent wp_strip_all_tags() array warning in single entry view

### DIFF
--- a/includes/admin/views/html-admin-page-entries-view.php
+++ b/includes/admin/views/html-admin-page-entries-view.php
@@ -195,6 +195,8 @@ if ( false !== $entry_index ) {
 													$answer_class = 'wrong_answer';
 												}
 											}
+											// Guard against non-scalar values (e.g. coupon data left as an array when the Coupons addon is deactivated).
+											$value = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
 											echo '<span class="list evf-answer-badge ' . esc_attr( $answer_class ) . '">' . esc_html( wp_strip_all_tags( $value ) ) . '</span>';
 										}
 									} else {
@@ -207,8 +209,13 @@ if ( false !== $entry_index ) {
 									} else {
 										$answer_class = 'wrong_answer';
 									}
+									$field_value = is_scalar( $field_value ) ? (string) $field_value : wp_json_encode( $field_value );
 									echo '<span class="list evf-answer-badge ' . esc_attr( $answer_class ) . '">' . esc_html( wp_strip_all_tags( $field_value ) ) . '</span>';
 								} else {
+									// Coupon and other addon fields can leave an array value when their addon is deactivated; normalize it so the output helpers below never receive an array.
+									if ( is_array( $field_value ) ) {
+										$field_value = wp_json_encode( $field_value );
+									}
 									$allow_html_types = apply_filters(
 										'everest_forms_entry_view_field_types_allowing_html',
 										array( 'wysiwyg', 'repeater-fields' ),

--- a/includes/admin/views/html-admin-page-entries-view.php
+++ b/includes/admin/views/html-admin-page-entries-view.php
@@ -195,8 +195,10 @@ if ( false !== $entry_index ) {
 													$answer_class = 'wrong_answer';
 												}
 											}
-											// Guard against non-scalar values (e.g. coupon data left as an array when the Coupons addon is deactivated).
-											$value = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
+											// Coupon data (and other addon field values) can remain an array when the owning addon is deactivated; encode arrays so the string helpers below never receive one. Scalars are left untouched.
+											if ( is_array( $value ) ) {
+												$value = wp_json_encode( $value );
+											}
 											echo '<span class="list evf-answer-badge ' . esc_attr( $answer_class ) . '">' . esc_html( wp_strip_all_tags( $value ) ) . '</span>';
 										}
 									} else {
@@ -209,7 +211,9 @@ if ( false !== $entry_index ) {
 									} else {
 										$answer_class = 'wrong_answer';
 									}
-									$field_value = is_scalar( $field_value ) ? (string) $field_value : wp_json_encode( $field_value );
+									if ( is_array( $field_value ) ) {
+										$field_value = wp_json_encode( $field_value );
+									}
 									echo '<span class="list evf-answer-badge ' . esc_attr( $answer_class ) . '">' . esc_html( wp_strip_all_tags( $field_value ) ) . '</span>';
 								} else {
 									// Coupon and other addon fields can leave an array value when their addon is deactivated; normalize it so the output helpers below never receive an array.


### PR DESCRIPTION
## Summary

Fixes **EVF-2430**. When a form entry contains a field whose value is stored as an **array** (e.g. an applied coupon from the Coupons addon) and the owning addon is later **deactivated**, the single-entry view (`html-admin-page-entries-view.php`) passes that array into `wp_strip_all_tags()` / `esc_html()`, producing:

> `Warning: wp_strip_all_tags expects parameter #1 ($text) to be a string, array given. in wp-includes/functions.php on line 6170`

While the addon is active it registers a formatter (`everest_forms_html_field_value`) that turns the array into a display string. Once deactivated, that formatter is gone and the raw array reaches the string output helpers.

## Fix

Add a uniform, **arrays-only** guard at the three value-output sites in the entry-view render block — if a value is still an array, encode it (`wp_json_encode`) before it reaches `wp_strip_all_tags()` / `esc_html()` / `make_clickable()`:

```php
if ( is_array( $value ) ) {
    $value = wp_json_encode( $value );
}
```

Display-only change — no stored data is modified.

## Impact analysis (why this is safe)

- **No-op in all normal flows.** Entry values reaching these points are strings; `is_array()` is `false`, so the guard does nothing and output is byte-identical to before.
- **No-op when the addon is active.** The Coupons addon's `everest_forms_html_field_value` filter stringifies the value *before* these guards, so the guard never fires.
- **Only the broken case changes.** An array value previously produced a PHP warning + empty/garbled output; it now renders as a lossless JSON string with no warning. Re-activating the addon restores the formatted display.
- **Scalars/null untouched.** Using `is_array()` (rather than `is_scalar() ? (string) : json`) means `null`, `bool`, `int`, `string` all pass through exactly as before — no `null` → `"null"` cosmetic change.
- **Scope is one template.** Entries list table, CSV/Excel export, REST API output, and email notifications use separate code paths and are unaffected.
- **Security.** Output remains escaped (`esc_html` / `wp_strip_all_tags` / `wp_kses_post`); JSON is additionally entity-encoded.

## Verification (Playwright + debug.log, A/B)

Reproduced by injecting a coupon-shaped serialized array (nested array value) into the single-entry meta via a temporary mu-plugin, with the Coupons addon inactive:

| Code state | `array given` warnings (`functions.php:6170`) |
|---|---|
| Original (buggy) | **1** — matches the report |
| Fixed | **0** (confirmed across reloads) |

With the fix, the value renders gracefully (e.g. `SAVE10{"amount":"5","type":"percent"}`).

Reported by: Subin Shakya · Evidence: https://subinshk.neetorecord.com/watch/a1e0394478296525b695

🤖 Generated with [Claude Code](https://claude.com/claude-code)