### PR TITLE
EVF-2428 fix: Add Repeat Row button visible in free version after deactivating Pro

### DIFF
--- a/includes/admin/builder/class-evf-builder-fields.php
+++ b/includes/admin/builder/class-evf-builder-fields.php
@@ -440,14 +440,16 @@ class EVF_Builder_Fields extends EVF_Builder_Page {
 
 		echo '</div>';
 		echo '<div class="clear evf-clear"></div>';
-		if ( defined( 'EVF_REPEATER_FIELDS_VERSION' ) ) {
+		// Repeater controls require the Pro plugin (EFP_VERSION); without it the addon
+		// does not register the repeater field, so the button must not be shown.
+		if ( defined( 'EVF_REPEATER_FIELDS_VERSION' ) && defined( 'EFP_VERSION' ) ) {
 			echo '<div class="evf-repeater-row-wrapper">'; // Repeater Row Wrapper starts.
 		}
 
 		$next_row_id = $row_ids ? max( $row_ids ) : 1;
 		echo '<div class="evf-add-row" data-total-rows="' . count( $structure ) . '" data-next-row-id="' . (int) $next_row_id . '"><span class="everest-forms-btn everest-forms-btn-primary dashicons dashicons-plus-alt">' . esc_html__( 'Add Row', 'everest-forms' ) . '</span></div>';
 
-		if ( defined( 'EVF_REPEATER_FIELDS_VERSION' ) ) {
+		if ( defined( 'EVF_REPEATER_FIELDS_VERSION' ) && defined( 'EFP_VERSION' ) ) {
 			echo '<div class="evf-add-row repeater-row" data-total-rows="' . count( $structure ) . '" data-next-row-id="' . (int) $next_row_id . '"><span class="everest-forms-btn everest-forms-btn-primary dashicons dashicons-plus-alt">' . esc_html__( 'Add Repeater Row', 'everest-forms' ) . '</span></div>';
 			echo '</div>'; // Repeater Row Wrapper ends.
 		}


### PR DESCRIPTION
## Summary

Fixes **EVF-2428**. After deactivating Everest Forms **Pro** while the **Repeater Fields** addon stays active, the builder still shows the repeater row wrapper and the **"Add Repeater Row"** button, even though the repeater feature is unavailable without Pro.

## Root cause

In `includes/admin/builder/class-evf-builder-fields.php`, the repeater wrapper and "Add Repeater Row" button were gated only on `defined( 'EVF_REPEATER_FIELDS_VERSION' )` — i.e. the **addon plugin being loaded**. But the Repeater Fields addon only registers the repeater field when **Pro** is active (`Plugin.php` checks `defined( 'EFP_VERSION' )`). So when Pro is deactivated, the field is no longer functional, yet the builder control remained visible because the addon constant was still defined.

## Fix

Gate the repeater wrapper and button on `EFP_VERSION` as well, matching the existing Pro-gating pattern already used in this file (the "Row Settings" control on line 362):

```php
if ( defined( 'EVF_REPEATER_FIELDS_VERSION' ) && defined( 'EFP_VERSION' ) ) {
```

- Pro active + addon active → both defined → control shows (unchanged).
- Pro **inactive** + addon active → `EFP_VERSION` undefined → control hidden (the fix).
- Addon inactive → unchanged (already hidden).

The change only *hides* the control when Pro is off; it does not alter behaviour when Pro is on.

## Verification (Playwright, builder, form with a repeater field, Pro deactivated)

| | Before | After |
|---|---|---|
| "Add Repeater Row" button | visible | **removed** |
| repeater row wrapper | present | **removed** |
| normal "Add Row" button | visible | **still visible** |

Frontend rendering was already correct (the addon doesn't hook `everest_forms_add_remove_buttons` when Pro is inactive, and the locked field is skipped) — confirmed via server-side render; this PR addresses the **builder** control.

`php -l` clean; LF line endings preserved (git stores LF via autocrlf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)