### PR TITLE
Fix: Query String example text & smart-tag icon alignment in Settings > Confirmation (EVF-2643)

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -5352,8 +5352,31 @@ p.search-box {
 				}
 
 				&#everest-forms-panel-field-settings-query_string-wrap {
+					flex-wrap: wrap;
+
+					> label {
+						flex: 0 0 300px;
+					}
+
+					> input[type='text'] {
+						flex: 1 1 0;
+						width: auto;
+						min-width: 0;
+					}
+
 					.evf-toggle-smart-tag-display {
-						top: 32px;
+						// Align the smart-tag icon inside the single-line input
+						// (the 2-column layout puts the input at the row top).
+						top: 5px;
+					}
+
+					// EVF-2643: keep the example/help text on its own line,
+					// aligned beneath the input instead of beside it.
+					.desc {
+						flex: 0 0 100%;
+						box-sizing: border-box;
+						padding-left: 312px; // 300px label column + 12px flex gap
+						margin: 6px 0 0;
 					}
 				}
 


### PR DESCRIPTION
## Summary

Fixes **[EVF-2643](https://themegrill.atlassian.net/browse/EVF-2643)** — in **Form Builder → Settings → Confirmation → Redirect to Custom Page → Append Query String**, the Query String example/help text rendered *beside* the input instead of below it.

## Root cause

`.everest-forms-panel-field` is a `display:flex` row (2-column: label + control). The Query String field's example text is appended via the `after` arg as a `<p class="desc">`, which became a third flex sibling — so it landed in the row to the right of the input. The stretched flex row also made the input look like a tall textarea, and the smart-tag (`<>`) icon (`top:32px`, calibrated for an older stacked layout) was pushed down toward the example text.

## Fix

Scoped entirely to `#everest-forms-panel-field-settings-query_string-wrap` in `assets/css/admin.scss`:

- `flex-wrap: wrap` + a fixed `300px` label column and `flex:1 1 0` input → preserves the panel's intended 2-column layout (matches the *Custom Page* field above it).
- `.desc` → `flex:0 0 100%` with `padding-left:312px` (300px label + 12px gap) → example text on its own line, aligned directly beneath the input.
- Smart-tag icon `top: 32px → 5px` → re-centered inside the single-line input.

## Build note

Only `assets/css/admin.scss` is committed (per project convention for fix branches — compiled `admin.css`/`admin-rtl.css` are regenerated at release via `grunt`). The compiled output was rebuilt and verified locally during testing.

## Verification

Reproduced and verified in the browser against the freshly compiled CSS (LTR + RTL):
- ✅ Example text sits below the input, aligned under it
- ✅ `<>` smart-tag icon centered inside the input's top-right
- ✅ No change to any other field (rule is ID-scoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EVF-2643]: https://themegrill.atlassian.net/browse/EVF-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ