### PR TITLE
Fix: show original file name for upload fields in All Forms entries view (EVF-2095)

### DIFF
--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -240,10 +240,21 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 		// Skip system fields
 		$skip_fields = array( 'entry_id', 'form_id', 'user_id', 'user_device', 'user_ip_address', 'viewed', 'starred', 'status' );
 
+		// Upload fields store only the hashed file URL in entry meta, so map each
+		// upload field's meta key to its original file name(s) from the full
+		// entry fields. This keeps the preview readable (e.g. "photo.png") instead
+		// of the full URL / hashed file name. See EVF-2095.
+		$upload_names = $this->get_upload_field_names( $entry );
+
 		// Find first non-empty field value
 		foreach ( $entry->meta as $key => $value ) {
 			if ( in_array( $key, $skip_fields, true ) || strpos( $key, '_' ) === 0 ) {
 				continue;
+			}
+
+			// Prefer the original file name(s) for upload fields.
+			if ( isset( $upload_names[ $key ] ) && '' !== $upload_names[ $key ] ) {
+				return $upload_names[ $key ];
 			}
 
 			// Process the value
@@ -255,6 +266,54 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 		}
 
 		return '<span class="na">&mdash;</span>';
+	}
+
+	/**
+	 * Build a map of upload field meta keys to their original file name(s).
+	 *
+	 * Entry meta only stores the public file URL (with a hashed file name), so
+	 * the original names are read from the full entry fields payload. See EVF-2095.
+	 *
+	 * @param object $entry Entry object.
+	 * @return array Map of meta key => escaped, comma-separated original file names.
+	 */
+	private function get_upload_field_names( $entry ) {
+		$names = array();
+
+		$fields = isset( $entry->fields ) ? evf_decode( $entry->fields ) : array();
+
+		if ( empty( $fields ) || ! is_array( $fields ) ) {
+			return $names;
+		}
+
+		foreach ( $fields as $field ) {
+			if ( empty( $field['meta_key'] ) || empty( $field['type'] ) ) {
+				continue;
+			}
+
+			if ( ! in_array( $field['type'], array( 'image-upload', 'file-upload' ), true ) ) {
+				continue;
+			}
+
+			if ( empty( $field['value_raw'] ) || ! is_array( $field['value_raw'] ) ) {
+				continue;
+			}
+
+			$file_names = array();
+			foreach ( $field['value_raw'] as $file ) {
+				if ( ! empty( $file['file_original'] ) ) {
+					$file_names[] = $file['file_original'];
+				} elseif ( ! empty( $file['name'] ) ) {
+					$file_names[] = $file['name'];
+				}
+			}
+
+			if ( ! empty( $file_names ) ) {
+				$names[ $field['meta_key'] ] = esc_html( implode( ', ', $file_names ) );
+			}
+		}
+
+		return $names;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes **[EVF-2095](https://themegrill.atlassian.net/browse/EVF-2095)** — in **Entries → All Forms**, an image/file upload field showed the file **URL / hashed file name** (e.g. `photo-3f9a1c7be2.png`) in the *Entry* preview column instead of the original file name.

## Root cause

The All Forms *Entry* column (`column_entry()`) builds its preview from **entry meta**. For upload fields, entry meta stores only the public file URL (`evf_entrymeta.meta_value = $field['value']`), and that URL's filename carries a unique hash suffix appended at upload time (`{base}-{wp_hash(...)}.{ext}`). `process_field_value()` did `basename($url)`, so it surfaced the hashed name — the "numbers attached" the reviewer reported. (The original report's "full URL" was the even earlier state, before a `basename()` patch.)

The original, human-readable file name is only available in the **full entry fields payload** (`evf_entries.fields` → `value_raw[].file_original`), not in entry meta.

## Fix

`column_entry()` now builds a map of each upload field's meta key → original file name(s), read from `$entry->fields` (`value_raw[].file_original`, falling back to `name`), via a new `get_upload_field_names()` helper. Upload fields prefer that name; everything else is unchanged.

- ✅ Single image → `photo.png`
- ✅ Multiple files → `beach.jpg, sunset.jpg`
- ✅ Non-upload fields → unchanged (no regression)
- ✅ Legacy entries without a fields payload → graceful fallback to existing behavior
- Output escaped with `esc_html()`.

## Verification

Verified end-to-end in the browser against a real (DB-inserted, faithfully structured) image entry in the All Forms view:

| State | Entry column |
|---|---|
| Before (pre-develop) | `mountain-3f9a1c7be2.png` (hashed) |
| After (this PR) | `mountain.png` ✅ |

Also covered the transformation with a standalone logic test (single/multiple/text/bare-url cases). Test entry was removed after verification.

## Note on the other ticket comments

- *"status column overlaps date column in All Forms"* — **not reproducible** on current `pre-develop`; the four columns distribute evenly (verified at 1900px, no overlap), so it appears already resolved by a later layout change. Left out of this PR to keep it focused on the image-field issue named in the branch.

PHP-only change — no build artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EVF-2095]: https://themegrill.atlassian.net/browse/EVF-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ