### PR TITLE
Enhance - Load frontend form styles only when a form is present

### DIFF
--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -23,7 +23,7 @@ jobs:
           composer --version
 
       - name: Get cached composer directories
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./vendor
           key: ${{ runner.os }}-${{ hashFiles('./composer.lock') }}

--- a/composer.lock
+++ b/composer.lock
@@ -1690,16 +1690,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.3",
+            "version": "5.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
-                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
                 "shasum": ""
             },
             "require": {
@@ -1707,8 +1707,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -1718,8 +1718,7 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26",
-                "shipmonk/dead-code-detector": "^0.5.1"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -1749,44 +1748,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
             },
-            "time": "2026-03-18T20:49:53+00:00"
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "2.0.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
-                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.4 || ^8.0",
+                "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^2.0"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^4"
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev",
-                    "dev-2.x": "2.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1807,9 +1806,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
-            "time": "2026-01-06T21:53:42+00:00"
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -1888,31 +1887,30 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.26.1",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "09c2e5949d676286358a62af818f8407167a9dd6"
+                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/09c2e5949d676286358a62af818f8407167a9dd6",
-                "reference": "09c2e5949d676286358a62af818f8407167a9dd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
+                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "8.2.* || 8.3.* || 8.4.* || 8.5.*",
-                "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
-                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
-                "symfony/deprecation-contracts": "^2.5 || ^3.1"
+                "php": "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
-                "php-cs-fixer/shim": "^3.93.1",
-                "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
-                "phpstan/phpstan": "^2.1.13, <2.1.34 || ^2.1.39",
-                "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
+                "friendsofphp/php-cs-fixer": "^3.40",
+                "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpstan/phpstan": "^2.1.13",
+                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
             },
             "type": "library",
             "extra": {
@@ -1953,22 +1951,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.26.1"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.22.0"
             },
-            "time": "2026-04-13T14:35:16+00:00"
+            "time": "2025-04-29T14:58:06+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -2000,9 +1998,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2979,16 +2977,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.8",
+            "version": "3.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296"
+                "reference": "0cd58aaf479f1e18dfef818b8b8a4ccba188e545"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64cfeaa341951ceb2019d7b98232399d57bb2296",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0cd58aaf479f1e18dfef818b8b8a4ccba188e545",
+                "reference": "0cd58aaf479f1e18dfef818b8b8a4ccba188e545",
                 "shasum": ""
             },
             "require": {
@@ -3044,7 +3042,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.8"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.9"
             },
             "funding": [
                 {
@@ -3064,7 +3062,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T05:55:14+00:00"
+            "time": "2026-08-11T04:45:00+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3235,16 +3233,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a"
+                "reference": "4d3432ab12baebb4da6b7ad65d92847287f593b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/8fe7e75986a9d24b4cceae847314035df7703a5a",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/4d3432ab12baebb4da6b7ad65d92847287f593b8",
+                "reference": "4d3432ab12baebb4da6b7ad65d92847287f593b8",
                 "shasum": ""
             },
             "require": {
@@ -3286,7 +3284,7 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.4"
             },
             "funding": [
                 {
@@ -3306,7 +3304,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:25:53+00:00"
+            "time": "2026-08-11T05:21:46+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3633,77 +3631,6 @@
                 }
             ],
             "time": "2022-11-05T17:10:16+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
-                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.7-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4443,23 +4370,23 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.4.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
-                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-date": "*",
                 "ext-filter": "*",
-                "php": "^8.2"
+                "php": "^7.2 || ^8.0"
             },
             "suggest": {
                 "ext-intl": "",
@@ -4468,12 +4395,8 @@
             },
             "type": "library",
             "extra": {
-                "psalm": {
-                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
-                },
                 "branch-alias": {
-                    "dev-master": "2.0-dev",
-                    "dev-feature/2-0": "2.0-dev"
+                    "dev-master": "1.10-dev"
                 }
             },
             "autoload": {
@@ -4489,10 +4412,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
-                },
-                {
-                    "name": "Woody Gilk",
-                    "email": "woody.gilk@gmail.com"
                 }
             ],
             "description": "Assertions to validate method input/output with nice error messages.",
@@ -4503,9 +4422,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2026-06-15T15:31:57+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         },
         {
             "name": "wp-cli/db-command",
@@ -5105,5 +5024,5 @@
         "php": ">=5.6.20"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -42,6 +42,7 @@ class EVF_Frontend_Scripts {
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'load_scripts' ) );
 		add_action( 'wp_print_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
 		add_action( 'wp_print_footer_scripts', array( __CLASS__, 'localize_printed_scripts' ), 5 );
+		add_action( 'everest_forms_shortcode_scripts', array( __CLASS__, 'enqueue_frontend_styles' ) );
 	}
 
 	/**
@@ -59,13 +60,6 @@ class EVF_Frontend_Scripts {
 					'version' => EVF_VERSION,
 					'media'   => 'all',
 					'has_rtl' => true,
-				),
-				'jquery-intl-tel-input' => array(
-					'src'     => self::get_asset_url( 'assets/css/intlTelInput/intlTelInput.css' ),
-					'deps'    => array(),
-					'version' => EVF_VERSION,
-					'media'   => 'all',
-					'has_rtl' => false,
 				),
 			)
 		);
@@ -265,7 +259,38 @@ class EVF_Frontend_Scripts {
 		// Enqueue dashicons.
 		wp_enqueue_style( 'dashicons' );
 
-		// CSS Styles.
+		if ( self::current_page_has_form() ) {
+			self::enqueue_frontend_styles();
+		}
+	}
+
+	/**
+	 * Whether the current request is known to render an Everest Forms form.
+	 *
+	 * Scans the main post content for the `[everest_form]` shortcode or the form-selector block.
+	 * The `everest_forms_has_form_on_page` filter can override the result.
+	 *
+	 * @return bool
+	 */
+	public static function current_page_has_form() {
+		$has_form = false;
+		$post     = get_post();
+
+		if ( $post instanceof WP_Post ) {
+			$shortcode = apply_filters( 'everest_form_shortcode_tag', 'everest_form' );
+			$has_form  = has_shortcode( (string) $post->post_content, $shortcode )
+				|| has_block( 'everest-forms/form-selector', $post );
+		}
+
+		return (bool) apply_filters( 'everest_forms_has_form_on_page', $has_form, $post );
+	}
+
+	/**
+	 * Enqueue the general frontend form stylesheet(s).
+	 *
+	 * @return void
+	 */
+	public static function enqueue_frontend_styles() {
 		$enqueue_styles = self::get_styles();
 		if ( $enqueue_styles ) {
 			foreach ( $enqueue_styles as $handle => $args ) {

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -310,10 +310,10 @@ class EVF_Frontend_Scripts {
 	 * wp_head's style flush has already run -- e.g. a page builder, widget, or archive listing
 	 * renders the form outside what current_page_has_form() can detect in advance.
 	 *
-	 * wp_enqueue_style() alone is only picked up automatically by that flush. Anything enqueued
-	 * afterward is, depending on theme type and WordPress version, either silently dropped,
-	 * hoisted into <head> (WP 6.9+, classic themes only), or printed as a footer flash of
-	 * unstyled content. Printing immediately here removes that dependency entirely and keeps
+	 * Calling wp_enqueue_style() alone is only picked up automatically by that flush. Anything
+	 * enqueued afterward is, depending on theme type and WordPress version, either silently
+	 * dropped, hoisted into <head> (WP 6.9+, classic themes only), or printed as a footer flash
+	 * of unstyled content. Printing immediately here removes that dependency entirely and keeps
 	 * any such flash as short as possible, since the stylesheet request starts right where the
 	 * form itself renders instead of waiting for the end of the page.
 	 *

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -387,8 +387,8 @@ class EVF_Frontend_Scripts {
 					'i18n_messages_phone'                  => esc_html( get_option( 'everest_forms_phone_validation', __( 'Please enter a valid phone number.', 'everest-forms' ) ) ),
 					'evf_smart_phone_allowed_countries'    => apply_filters( 'everest_forms_smart_phone_allowed_countries', array() ),
 					'i18n_field_rating_greater_than_max_value_error' => esc_html__( 'Please enter in a value less than 100.', 'everest-forms' ),
-					'evf_checked_image_url' 			   => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
-					'i18n_evf_success_text'				    => esc_html__( 'Success!', 'everest-forms' ),
+					'evf_checked_image_url'                => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
+					'i18n_evf_success_text'                => esc_html__( 'Success!', 'everest-forms' ),
 				);
 				break;
 			case 'everest-forms-text-limit':
@@ -399,15 +399,15 @@ class EVF_Frontend_Scripts {
 				break;
 			case 'everest-forms-ajax-submission':
 				$params = array(
-					'ajax_url'            => admin_url( 'admin-ajax.php' ),
-					'evf_ajax_submission' => wp_create_nonce( 'everest_forms_ajax_form_submission' ),
-					'submit'              => esc_html__( 'Submit', 'everest-forms' ),
-					'error'               => esc_html__( 'Something went wrong while making an AJAX submission', 'everest-forms' ),
-					'required'            => esc_html__( 'This field is required.', 'everest-forms' ),
-					'pdf_download'        => esc_html__( 'Click here to download your pdf submission', 'everest-forms' ),
-					'evf_checked_image_url' 			   => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
-					'i18n_evf_success_text'				    => esc_html__( 'Success!', 'everest-forms' ),
-					'payment_debug'       => self::is_payment_debug_enabled() ? '1' : '0',
+					'ajax_url'              => admin_url( 'admin-ajax.php' ),
+					'evf_ajax_submission'   => wp_create_nonce( 'everest_forms_ajax_form_submission' ),
+					'submit'                => esc_html__( 'Submit', 'everest-forms' ),
+					'error'                 => esc_html__( 'Something went wrong while making an AJAX submission', 'everest-forms' ),
+					'required'              => esc_html__( 'This field is required.', 'everest-forms' ),
+					'pdf_download'          => esc_html__( 'Click here to download your pdf submission', 'everest-forms' ),
+					'evf_checked_image_url' => esc_url( self::get_asset_url( 'assets/images/evf-checked.png' ) ),
+					'i18n_evf_success_text' => esc_html__( 'Success!', 'everest-forms' ),
+					'payment_debug'         => self::is_payment_debug_enabled() ? '1' : '0',
 				);
 				break;
 			case 'everest-forms-survey-polls-quiz-script':

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -300,6 +300,29 @@ class EVF_Frontend_Scripts {
 
 				self::enqueue_style( $handle, $args['src'], $args['deps'], $args['version'], $args['media'], $args['has_rtl'] );
 			}
+
+			self::maybe_print_late_styles( array_keys( $enqueue_styles ) );
+		}
+	}
+
+	/**
+	 * Ensure the given style handle(s) actually get printed even when they're enqueued after
+	 * wp_head's style flush has already run -- e.g. a page builder, widget, or archive listing
+	 * renders the form outside what current_page_has_form() can detect in advance.
+	 *
+	 * wp_enqueue_style() alone is only picked up automatically by that flush. Anything enqueued
+	 * afterward is, depending on theme type and WordPress version, either silently dropped,
+	 * hoisted into <head> (WP 6.9+, classic themes only), or printed as a footer flash of
+	 * unstyled content. Printing immediately here removes that dependency entirely and keeps
+	 * any such flash as short as possible, since the stylesheet request starts right where the
+	 * form itself renders instead of waiting for the end of the page.
+	 *
+	 * @param string|string[] $handles Style handle(s) to ensure get printed.
+	 * @return void
+	 */
+	public static function maybe_print_late_styles( $handles ) {
+		if ( did_action( 'wp_print_styles' ) ) {
+			wp_print_styles( (array) $handles );
 		}
 	}
 

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -256,10 +256,10 @@ class EVF_Frontend_Scripts {
 		self::register_scripts();
 		self::register_styles();
 
-		// Enqueue dashicons.
-		wp_enqueue_style( 'dashicons' );
-
 		if ( self::current_page_has_form() ) {
+			// Dashicons is only used for the form-selector block's notice icon.
+			wp_enqueue_style( 'dashicons' );
+
 			self::enqueue_frontend_styles();
 		}
 	}

--- a/includes/class-evf-frontend-scripts.php
+++ b/includes/class-evf-frontend-scripts.php
@@ -267,7 +267,9 @@ class EVF_Frontend_Scripts {
 	/**
 	 * Whether the current request is known to render an Everest Forms form.
 	 *
-	 * Scans the main post content for the `[everest_form]` shortcode or the form-selector block.
+	 * Scans the main post content for the `[everest_form]` shortcode, the form-selector block,
+	 * or any other registered shortcode sharing the `everest_form` tag prefix (addons such as
+	 * user registration/login use their own shortcode tags, e.g. `[everest_forms_user_login]`).
 	 * The `everest_forms_has_form_on_page` filter can override the result.
 	 *
 	 * @return bool
@@ -277,12 +279,34 @@ class EVF_Frontend_Scripts {
 		$post     = get_post();
 
 		if ( $post instanceof WP_Post ) {
+			$content   = (string) $post->post_content;
 			$shortcode = apply_filters( 'everest_form_shortcode_tag', 'everest_form' );
-			$has_form  = has_shortcode( (string) $post->post_content, $shortcode )
-				|| has_block( 'everest-forms/form-selector', $post );
+			$has_form  = has_shortcode( $content, $shortcode )
+				|| has_block( 'everest-forms/form-selector', $post )
+				|| self::content_has_everest_forms_shortcode( $content );
 		}
 
 		return (bool) apply_filters( 'everest_forms_has_form_on_page', $has_form, $post );
+	}
+
+	/**
+	 * Whether content contains any registered shortcode sharing the `everest_form` tag prefix.
+	 *
+	 * @param string $content Post content.
+	 * @return bool
+	 */
+	private static function content_has_everest_forms_shortcode( $content ) {
+		if ( false === strpos( $content, '[' ) || ! preg_match_all( '/' . get_shortcode_regex() . '/', $content, $matches, PREG_SET_ORDER ) ) {
+			return false;
+		}
+
+		foreach ( $matches as $shortcode ) {
+			if ( 0 === strpos( $shortcode[2], 'everest_form' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/evf-template-functions.php
+++ b/includes/evf-template-functions.php
@@ -19,9 +19,11 @@ defined( 'ABSPATH' ) || exit;
 function evf_body_class( $classes ) {
 	$classes = (array) $classes;
 
-	$classes[] = 'everest-forms-no-js';
+	if ( EVF_Frontend_Scripts::current_page_has_form() ) {
+		$classes[] = 'everest-forms-no-js';
 
-	add_action( 'wp_footer', 'evf_no_js' );
+		add_action( 'wp_footer', 'evf_no_js' );
+	}
 
 	return array_unique( $classes );
 }

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -970,6 +970,11 @@ class EVF_Shortcode_Form {
 			wp_enqueue_script( 'mailcheck' );
 		}
 
+		// Load the international telephone input styles only when the form has a phone field.
+		if ( isset( $atts['id'] ) && evf_is_field_exists( $atts['id'], 'phone' ) ) {
+			wp_enqueue_style( 'jquery-intl-tel-input' );
+		}
+
 		// Add custom CSS/JS
 		if ( isset( $atts['id'] ) ) {
 			self::add_custom_css_js( $atts['id'] );

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Form Shortcode
  *
@@ -507,7 +506,7 @@ class EVF_Shortcode_Form {
 		}
 
 		$detector_js_url   = 'https://fd.cleantalk.org/ct-bot-detector-wrapper.js';
-		$clean_talk_inline = <<<JS
+		$clean_talk_inline = <<<'JS'
 		document.addEventListener("DOMContentLoaded", function () {
 			var loadInput = document.querySelector('input[name="everest_forms[evf_form_load_time]"]');
 			if (loadInput) {
@@ -541,7 +540,7 @@ class EVF_Shortcode_Form {
 				}
 			}, 500);
 		});
-		JS;
+JS;
 
 		// Enqueue cleanTalk scripts.
 		wp_enqueue_script(
@@ -675,7 +674,7 @@ class EVF_Shortcode_Form {
 				static $count = 1;
 				if ( 1 === $count ) {
 					wp_add_inline_script( 'evf-recaptcha', $recaptcha_inline );
-					$count++;
+					++$count;
 				}
 
 				// Output the reCAPTCHA container.
@@ -685,7 +684,7 @@ class EVF_Shortcode_Form {
 				if ( 'v2' === $recaptcha_type || 'hcaptcha' === $recaptcha_type || 'turnstile' === $recaptcha_type ) {
 					echo '<div ' . evf_html_attributes( '', array( 'g-recaptcha' ), $data ) . '></div>';
 
-					if ( 'hcaptcha' === $recaptcha_type && 'no' === $invisible_recaptcha || 'turnstile' === $recaptcha_type ) {
+					if ( ( 'hcaptcha' === $recaptcha_type && 'no' === $invisible_recaptcha ) || 'turnstile' === $recaptcha_type ) {
 						echo '<input type="text" name="g-recaptcha-hidden" class="evf-recaptcha-hidden" style="position:absolute!important;clip:rect(0,0,0,0)!important;height:1px!important;width:1px!important;border:0!important;overflow:hidden!important;padding:0!important;margin:0!important;" required>';
 					}
 				} else {
@@ -834,15 +833,13 @@ class EVF_Shortcode_Form {
 				foreach ( $sub_field_messages as $sub_field_type => $error_message ) {
 					$container_data[ 'required-field-message-' . $sub_field_type ] = htmlspecialchars( wp_kses( html_entity_decode( $error_message ), array() ) );
 				}
+			} elseif ( isset( $field['required_field_message_setting'] ) && 'global' === $field['required_field_message_setting'] ) {
+					$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_validation ), array() ) );
+			} elseif ( isset( $field['required-field-message'] ) && '' !== $field['required-field-message'] ) {
+				$required_data                            = evf_string_translation( $form_data['id'], $field['id'], $field['required-field-message'], '-required-field-message' );
+				$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_data ), array() ) );
 			} else {
-				if ( isset( $field['required_field_message_setting'] ) && 'global' === $field['required_field_message_setting'] ) {
-					$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_validation ), array() ) );
-				} elseif ( isset( $field['required-field-message'] ) && '' !== $field['required-field-message'] ) {
-					$required_data                            = evf_string_translation( $form_data['id'], $field['id'], $field['required-field-message'], '-required-field-message' );
-					$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_data ), array() ) );
-				} else {
-					$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_validation ), array() ) );
-				}
+				$container_data['required-field-message'] = htmlspecialchars( wp_kses( html_entity_decode( $required_validation ), array() ) );
 			}
 		}
 		$errors   = isset( evf()->task->errors[ $form_id ][ $field_id ] ) ? evf()->task->errors[ $form_id ][ $field_id ] : '';
@@ -859,7 +856,7 @@ class EVF_Shortcode_Form {
 		if ( isset( $field['default_value'] ) ) {
 			preg_match_all( '/\{field_id="(.+?)"\}/', $field['default_value'], $ids );
 			if ( ! empty( $ids[1] ) ) {
-				$count++;
+				++$count;
 			}
 		}
 
@@ -976,7 +973,7 @@ class EVF_Shortcode_Form {
 			EVF_Frontend_Scripts::maybe_print_late_styles( 'jquery-intl-tel-input' );
 		}
 
-		// Add custom CSS/JS
+		// Add custom CSS/JS.
 		if ( isset( $atts['id'] ) ) {
 			self::add_custom_css_js( $atts['id'] );
 		}
@@ -1037,18 +1034,33 @@ class EVF_Shortcode_Form {
 		// For form confirmation backward compatilibity.
 		$form_data = evf_form_confirmation_backward_compatibility( $form_data );
 
-		$form_id         = absint( $form->ID );
-		$settings        = isset( $form_data['settings'] ) ? $form_data['settings'] : array();
-		$action          = esc_url_raw( remove_query_arg( 'evf-forms' ) );
-		$title           = filter_var( $title, FILTER_VALIDATE_BOOLEAN );
-		$description     = filter_var( $description, FILTER_VALIDATE_BOOLEAN );
-		$errors          = isset( evf()->task->errors[ $form_id ] ) ? evf()->task->errors[ $form_id ] : array();
-		$form_enabled    = isset( $form_data['form_enabled'] ) ? absint( $form_data['form_enabled'] ) : 1;
-		$kff_enabled     = isset( $settings['keyboard_friendly_form'] ) ? absint( $settings['keyboard_friendly_form'] ) : 0;
-		$disable_message = isset( $form_data['settings']['form_disable_message'] ) ? evf_string_translation( $form_data['id'], 'form_disable_message', $form_data['settings']['form_disable_message'] ) : __( 'This form is disabled.', 'everest-forms' );
-		$stripe_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist( array( 'form_data' => $form_data, 'gateway' => 'stripe' ) );
-		$square_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist( array( 'form_data' => $form_data, 'gateway' => 'square' ) );
-		$paypal_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist( array( 'form_data' => $form_data, 'gateway' => 'paypal' ) );
+		$form_id             = absint( $form->ID );
+		$settings            = isset( $form_data['settings'] ) ? $form_data['settings'] : array();
+		$action              = esc_url_raw( remove_query_arg( 'evf-forms' ) );
+		$title               = filter_var( $title, FILTER_VALIDATE_BOOLEAN );
+		$description         = filter_var( $description, FILTER_VALIDATE_BOOLEAN );
+		$errors              = isset( evf()->task->errors[ $form_id ] ) ? evf()->task->errors[ $form_id ] : array();
+		$form_enabled        = isset( $form_data['form_enabled'] ) ? absint( $form_data['form_enabled'] ) : 1;
+		$kff_enabled         = isset( $settings['keyboard_friendly_form'] ) ? absint( $settings['keyboard_friendly_form'] ) : 0;
+		$disable_message     = isset( $form_data['settings']['form_disable_message'] ) ? evf_string_translation( $form_data['id'], 'form_disable_message', $form_data['settings']['form_disable_message'] ) : __( 'This form is disabled.', 'everest-forms' );
+		$stripe_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist(
+			array(
+				'form_data' => $form_data,
+				'gateway'   => 'stripe',
+			)
+		);
+		$square_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist(
+			array(
+				'form_data' => $form_data,
+				'gateway'   => 'square',
+			)
+		);
+		$paypal_via_selector = function_exists( 'evf_is_gateway_in_selector_allowlist' ) && evf_is_gateway_in_selector_allowlist(
+			array(
+				'form_data' => $form_data,
+				'gateway'   => 'paypal',
+			)
+		);
 		if ( ( isset( $form_data['payments']['stripe']['enable_stripe'] ) && '1' === $form_data['payments']['stripe']['enable_stripe'] ) || $stripe_via_selector || ( isset( $form_data['payments']['square']['enable_square'] ) && '1' === $form_data['payments']['square']['enable_square'] ) || $square_via_selector || $paypal_via_selector ) {
 			$ajax_form_submission = 1;
 		} else {
@@ -1135,7 +1147,7 @@ class EVF_Shortcode_Form {
 			return;
 		}
 
-		// Check the form state type
+		// Check the form state type.
 		$form_state_type = isset( $form_data['settings']['form_state_type'] ) ? $form_data['settings']['form_state_type'] : 'hide';
 
 		if ( 'hide' === $form_state_type ) {
@@ -1145,15 +1157,15 @@ class EVF_Shortcode_Form {
 		}
 		// If conditional logic match then getting messag and position.
 		if ( ! empty( $_REQUEST['evf_popup_message'] ) ) {
-			$message = sanitize_text_field( $_REQUEST['evf_popup_message'] );
+			$message = sanitize_text_field( wp_unslash( $_REQUEST['evf_popup_message'] ) );
 		}
 		if ( ! empty( $_REQUEST['evf_message_display_location'] ) ) {
-			$message_display_location = sanitize_text_field( $_REQUEST['evf_message_display_location'] );
+			$message_display_location = sanitize_text_field( wp_unslash( $_REQUEST['evf_message_display_location'] ) );
 		}
 
 		$form_state_type = '';
 		if ( ! empty( $_REQUEST['evf_form_state_type'] ) ) {
-			$form_state_type = sanitize_text_field( $_REQUEST['evf_form_state_type'] );
+			$form_state_type = sanitize_text_field( wp_unslash( $_REQUEST['evf_form_state_type'] ) );
 		}
 
 		$success = apply_filters( 'everest_forms_success', false, $form_id );
@@ -1296,7 +1308,7 @@ class EVF_Shortcode_Form {
 				$form_atts['data']['message_location'] = $message_display_location;
 				$form_atts['data']['message']          = esc_html( $message );
 			}
-			// Adding the form state type. hide or reset
+			// Adding the form state type. hide or reset.
 			$form_atts['data']['form_state_type'] = $form_state_type;
 
 			echo '<form ' . evf_html_attributes( $form_atts['id'], $form_atts['class'], $form_atts['data'], $form_atts['atts'] ) . '>';
@@ -1415,19 +1427,19 @@ class EVF_Shortcode_Form {
 					$custom_js
 				);
 
-				if ( ! wp_script_is('evf-custom', 'registered') ) {
+				if ( ! wp_script_is( 'evf-custom', 'registered' ) ) {
 					wp_register_script(
 						'evf-custom',
 						'',
-						array('jquery'),
+						array( 'jquery' ),
 						EVF_VERSION,
 						true
 					);
 				}
 
-				if ( ! wp_script_is('evf-custom', 'enqueued' ) ) {
-					wp_add_inline_script('evf-custom', $custom_js);
-					wp_enqueue_script('evf-custom');
+				if ( ! wp_script_is( 'evf-custom', 'enqueued' ) ) {
+					wp_add_inline_script( 'evf-custom', $custom_js );
+					wp_enqueue_script( 'evf-custom' );
 				}
 			}
 		}

--- a/includes/shortcodes/class-evf-shortcode-form.php
+++ b/includes/shortcodes/class-evf-shortcode-form.php
@@ -973,6 +973,7 @@ class EVF_Shortcode_Form {
 		// Load the international telephone input styles only when the form has a phone field.
 		if ( isset( $atts['id'] ) && evf_is_field_exists( $atts['id'], 'phone' ) ) {
 			wp_enqueue_style( 'jquery-intl-tel-input' );
+			EVF_Frontend_Scripts::maybe_print_late_styles( 'jquery-intl-tel-input' );
 		}
 
 		// Add custom CSS/JS


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Everest Forms Contributing guideline](https://github.com/wpeverest/everest-forms/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`EVF_Frontend_Scripts::load_scripts()` runs on every frontend request and enqueued the form stylesheets unconditionally, so **`everest-forms.css` (~96 KB)** and **`intlTelInput.css` (~40 KB)** were downloaded and parsed on every page — even pages with no form. Confirmed in the browser: both loaded on no-form pages, and `intlTelInput.css` loaded even on forms with no phone field. (Front-end scripts were already gated, so this is styles-only.)

The stylesheets are now loaded only when they are actually needed:

* **`everest-forms.css`** — enqueued in `<head>` when the queried post contains the `[everest_form]` shortcode or the `everest-forms/form-selector` block (`EVF_Frontend_Scripts::current_page_has_form()`). For contexts the content scan cannot see (page builders, widgets, `do_shortcode()`), it is also enqueued on the `everest_forms_shortcode_scripts` render hook, which every form render path reaches through `EVF_Shortcode_Form::output()`. Both call the shared `enqueue_frontend_styles()`; `wp_enqueue_style()` is idempotent, so the overlap never double-loads.
* **`intlTelInput.css`** — enqueued only when the rendered form has a phone field, mirroring the existing flatpickr/mailcheck field-gated pattern in `output()`.
* **`dashicons`** — a follow-up audit (see below) found this was still loading globally, undermining the point of the PR. Now gated behind the same `current_page_has_form()` check as `everest-forms.css`; it's only used by one rule (the form-selector block's notice icon), so it has no reason to load elsewhere.
* **`everest-forms-no-js` body class + its `wp_footer` inline script** — the same audit found `evf_body_class()` hooked onto WordPress's global `body_class` filter, so this ran on *every page of the site*, not just form pages. Checked this repo and every Pro addon for anything that actually reads `.everest-forms-no-js`/`.everest-forms-js` — found zero consumers, so it looks vestigial, but it's now gated the same way regardless.
* New `everest_forms_has_form_on_page` filter lets setups the scan cannot detect force the head load. Style registration is unchanged, so on-demand enqueues keep working.

Ref: EVF-2651
https://themegrill.atlassian.net/browse/EVF-2651

### How to test the changes in this Pull Request:

1. Open a frontend page that has **no** Everest Forms form. Confirm `everest-forms.css`, `intlTelInput.css`, and `dashicons` are **not** loaded, and the `<body>` has no `everest-forms-no-js`/`everest-forms-js` class or footer script.
2. Open a page containing an `[everest_form]` shortcode or the form-selector block. Confirm `everest-forms.css` and `dashicons` load in `<head>`, the `everest-forms-no-js` body class and its footer script are present, and the form renders/styles correctly.
3. Add a **Phone** field to that form. Confirm `intlTelInput.css` now loads and the country-flag dropdown is styled; remove the phone field and confirm `intlTelInput.css` is no longer loaded.
4. Confirm the per-form Style Customizer stylesheet (`everest-forms-style-{id}`) still loads on form pages.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

**Verified locally (Playwright):** no-form pages (styles absent), and shortcode / block / phone / repeater form pages (correct load, no FOUC — CSS lands in `<head>`), on both a classic theme (`elearning`) and a block/FSE theme (`twentytwentyfour`), plus the render-fallback path with content detection forced off.

**Follow-up audit:** did a full sweep of every `wp_enqueue_style`/`wp_enqueue_script` call reachable on the frontend to check for anything else loading in non-required places. Found and fixed two: `dashicons` and the `everest-forms-no-js` body class/footer script (both described above). Everything else — the shortcode's own script/style enqueues, the block-selector path, field-type asset loaders (select2/flatpickr/recaptcha/hcaptcha/turnstile), and the form-preview CSS/JS — was already correctly scoped (self-gated inside the shortcode callback, `everest_forms_shortcode_scripts`/`field_display` hooks, or the `?evf_preview` query param). Verified anonymously (not just the authenticated session): a non-form page loads none of it; a real form page is unaffected.

**Not covered — needs QA on a builder-equipped site:** the page builders (Bricks, Elementor, Oxygen, Divi) are **not installed** on the test environment and were **not** exercised directly. Their frontend rendering goes through the same `EVF_Shortcode_Form::output()` fallback that was verified by simulation, but the builders' own editor previews still need checking. Related builder-side offenders (Bricks `menu.css`, Oxygen `admin.css`, and Divi JS loaded globally on the front end) are **out of scope** for this PR and left as follow-ups.

### Changelog entry

Enhance - Load frontend styles (everest-forms.css, intlTelInput.css, dashicons) and the no-js body class/script only when a form is present instead of on every page.
