### PR TITLE
fix(ai): make everest_forms_ai_is_local_site filter actually reachable

### DIFF
--- a/includes/Integrations/AI/class-evf-ai-registration.php
+++ b/includes/Integrations/AI/class-evf-ai-registration.php
@@ -56,46 +56,41 @@ class EVF_AI_Registration {
 	 * @return bool
 	 */
 	public static function is_local_site(): bool {
+		$host = wp_parse_url( site_url(), PHP_URL_HOST );
+		$host = $host ? strtolower( $host ) : '';
+
 		// An explicit local-gateway override (see the themegrill-ai-cloud README's "Setup —
 		// WordPress Plugin" instructions: `define('TG_AI_GATEWAY_URL', 'http://localhost:8000')`)
 		// means the developer has deliberately pointed this install at a gateway running on
-		// their own machine to test AI features end-to-end. The heuristics below exist to keep
-		// PRODUCTION sites from burning free-tier quota on throwaway local installs pointed at
-		// the real gateway — that protection is moot once a LOOPBACK gateway is configured, and
-		// without this the documented local-dev setup could never actually work on ANY local WP
+		// their own machine to test AI features end-to-end, so the heuristics below don't apply
+		// — without this the documented local-dev setup could never work on ANY local WP
 		// environment (Local by Flywheel, Valet, MAMP, …), since `WP_ENVIRONMENT_TYPE=local` and
 		// `.local`/`.test` domains are exactly what those tools use by default.
 		if ( defined( 'TG_AI_GATEWAY_URL' ) && self::is_loopback_url( TG_AI_GATEWAY_URL ) ) {
-			return false;
-		}
+			$is_local = false;
+		} else {
+			$is_local = ( function_exists( 'wp_get_environment_type' ) && 'local' === wp_get_environment_type() )
+				|| in_array( $host, array( 'localhost', '127.0.0.1', '::1' ), true );
 
-		if ( function_exists( 'wp_get_environment_type' ) && 'local' === wp_get_environment_type() ) {
-			return true;
-		}
-
-		$host = wp_parse_url( site_url(), PHP_URL_HOST );
-		if ( empty( $host ) ) {
-			return false;
-		}
-		$host = strtolower( $host );
-
-		if ( in_array( $host, array( 'localhost', '127.0.0.1', '::1' ), true ) ) {
-			return true;
-		}
-
-		foreach ( array( '.local', '.test', '.localhost' ) as $suffix ) {
-			if ( substr( $host, -strlen( $suffix ) ) === $suffix ) {
-				return true;
+			if ( ! $is_local ) {
+				foreach ( array( '.local', '.test', '.localhost' ) as $suffix ) {
+					if ( '' !== $host && substr( $host, -strlen( $suffix ) ) === $suffix ) {
+						$is_local = true;
+						break;
+					}
+				}
 			}
 		}
 
 		/**
-		 * Filter whether the current site is treated as local for AI features.
+		 * Filter whether the current site is treated as local for AI features — the final say
+		 * over the heuristics above, e.g. to test the live gateway from a .local domain (set
+		 * this to __return_false), or to block a host the heuristics miss.
 		 *
-		 * @param bool   $is_local Whether the site is considered local.
+		 * @param bool   $is_local Whether the built-in heuristics consider this site local.
 		 * @param string $host     The detected site host.
 		 */
-		return (bool) apply_filters( 'everest_forms_ai_is_local_site', false, $host );
+		return (bool) apply_filters( 'everest_forms_ai_is_local_site', $is_local, $host );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `EVF_AI_Registration::is_local_site()` returns early on `WP_ENVIRONMENT_TYPE=local` or a `.local`/`.test`/`.localhost` domain, before ever reaching the `everest_forms_ai_is_local_site` filter — even though the filter's own docblock says it's "the final say."
- In practice this makes the filter dead code for the most common local-dev setups (Local by Flywheel, Valet, MAMP all default to one of those), since there's no way to override the built-in heuristic once it fires.
- Fix: compute the heuristic result first, then always run it through the filter, so a `.local` install can be deliberately pointed at the live gateway for testing (e.g. `add_filter('everest_forms_ai_is_local_site', '__return_false')`), without changing default behavior for any site that doesn't use the filter.

## Test plan
- [x] `php -l` clean
- [x] Verified live on a `.local` Local-by-Flywheel site: before the fix, the filter had no effect and `aiEnabled` stayed false; after the fix, adding the filter override flips `aiEnabled` to true and the AI launcher renders.
- [x] Confirmed no change in behavior for the default case (no filter registered) — same heuristics, same order, just reachable by the filter afterward instead of bypassing it.