### PR TITLE
Fix - Missing capability checks in entries bulk actions and empty trash (IDOR)

### DIFF
--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -864,6 +864,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 				case 'star':
 				case 'unstar':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							++$count;
 						}
@@ -880,6 +883,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 				case 'read':
 				case 'unread':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							++$count;
 						}
@@ -895,6 +901,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'approved':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
 							$header      = "Reply-To: {$admin_email} \r\n";
@@ -959,6 +968,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'denied':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
 							$header      = "Reply-To: {$admin_email} \r\n";
@@ -1023,6 +1035,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'trash':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_delete_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, 'trash' ) ) {
 							++$count;
 						}
@@ -1038,6 +1053,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'untrash':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, 'publish' ) ) {
 							++$count;
 						}
@@ -1053,6 +1071,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'delete':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_delete_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::remove_entry( $entry_id, $form_id ) ) {
 							++$count;
 						}
@@ -1068,6 +1089,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'spam':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, 'spam' ) ) {
 							++$count;
 						}
@@ -1083,6 +1107,9 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'unspam':
 					foreach ( $entry_ids as $entry_id ) {
+						if ( ! current_user_can( 'everest_forms_edit_entry', $entry_id ) ) {
+							continue;
+						}
 						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							++$count;
 						}

--- a/includes/admin/class-evf-admin-entries.php
+++ b/includes/admin/class-evf-admin-entries.php
@@ -331,6 +331,10 @@ class EVF_Admin_Entries {
 		if ( isset( $_GET['form_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$form_id = absint( $_GET['form_id'] ); // phpcs:ignore WordPress.Security.NonceVerification
 
+			if ( $form_id && ! current_user_can( 'everest_forms_delete_form_entries', $form_id ) ) {
+				wp_die( esc_html__( 'You do not have permission to empty trash for this form.', 'everest-forms' ), 403 );
+			}
+
 			if ( $form_id ) {
 				$count     = 0;
 				$results   = $wpdb->get_results( $wpdb->prepare( "SELECT entry_id FROM {$wpdb->prefix}evf_entries WHERE `status` = 'trash' AND form_id = %d", $form_id ) ); // WPCS: cache ok, DB call ok.


### PR DESCRIPTION
## Summary

Follow-up to the capability-check fix in `e216be07` (#1619), which addressed a WordPress.org-reported IDOR (CWE-862/CWE-639) in the single-entry `delete`/`trash`/`untrash` handlers in `EVF_Admin_Entries`. While verifying that fix, the same missing-authorization pattern was found still present in two related code paths that the original report didn't cover:

- **`EVF_Admin_Entries_Table_List::process_bulk_action()`** — every bulk action (star/unstar, read/unread, approve/deny, trash, untrash, delete, spam/unspam) took `entry[]` IDs directly from the request and mutated them via `update_status()` / `remove_entry()` with only the generic `bulk-entries` nonce — no per-entry `current_user_can()` check. A user with only the `_own` delete/edit capability could replay their own valid bulk-action nonce against another author's `entry_id`.
- **`EVF_Admin_Entries::empty_trash()`** — permanently deleted every trashed entry for a given `form_id` with no capability check on that form at all.

This PR adds the same per-object capability checks the plugin already uses everywhere else (`everest_forms_edit_entry` / `everest_forms_delete_entry` per entry, resolved to own/others via `filter_map_meta_cap()`; `everest_forms_delete_form_entries` for the form-scoped trash-empty).

## Changes

- `includes/admin/class-evf-admin-entries-table-list.php`: each `process_bulk_action()` case now skips (`continue`) any `entry_id` the current user isn't authorized for, instead of processing it unconditionally.
- `includes/admin/class-evf-admin-entries.php`: `empty_trash()` now `wp_die(403)`s if the current user lacks `everest_forms_delete_form_entries` for the target `form_id`.

## Test plan

- [x] Reproduced the report's PoC methodology live on a local multi-author install: a role-less test user granted only `everest_forms_view_entries` / `edit_entries` / `delete_entries` (no `_others`), with a form+entry of their own and a separate victim form+entry owned by another author.
- [x] Logged in as the test user, scraped real nonces from their own Entries screen, replayed them against the victim's `entry_id`/`form_id` across all 5 mutation paths (single delete, single trash, single untrash, bulk delete, empty trash) — all blocked with 403, victim data unchanged in the DB.
- [x] Negative control: temporarily reverted just this patch and reran the identical bulk-delete / empty-trash requests — confirmed they succeeded and permanently deleted the victim's entries, proving the vulnerability was real before this fix.
- [x] `php -l` clean on both files; pre-commit lint-staged/PHPCS pass.