### PR TITLE
Entries: make approval/denial email content customizable (EVF-2724)

### DIFF
--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -895,7 +895,7 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'approved':
 					foreach ( $entry_ids as $entry_id ) {
-						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
+						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction, true ) ) {
 							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
 							$header      = "Reply-To: {$admin_email} \r\n";
 							$header     .= 'Content-Type: text/html; charset=UTF-8';
@@ -959,7 +959,7 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'denied':
 					foreach ( $entry_ids as $entry_id ) {
-						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
+						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction, true ) ) {
 							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
 							$header      = "Reply-To: {$admin_email} \r\n";
 							$header     .= 'Content-Type: text/html; charset=UTF-8';

--- a/includes/admin/class-evf-admin-entries-table-list.php
+++ b/includes/admin/class-evf-admin-entries-table-list.php
@@ -895,128 +895,14 @@ class EVF_Admin_Entries_Table_List extends EVF_Base_List_Table {
 					break;
 				case 'approved':
 					foreach ( $entry_ids as $entry_id ) {
-						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction, true ) ) {
-							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
-							$header      = "Reply-To: {$admin_email} \r\n";
-							$header     .= 'Content-Type: text/html; charset=UTF-8';
-							$subject     = '';
-							$message     = '';
-
-							$entry      = evf_get_entry( $entry_id );
-							$entry_date = $entry->date_created;
-							$entry_data = $entry->meta;
-							$site_name  = get_option( 'blogname' );
-
-							$first_name = '';
-							$last_name  = '';
-							$email      = '';
-							$name       = '';
-
-							foreach ( $entry_data as $key => $value ) {
-								if ( preg_match( '/^name/', $key ) ) {
-									$name = $value;
-								}
-
-								if ( preg_match( '/^first_name_/', $key ) ) {
-									$first_name = $value;
-								}
-
-								if ( preg_match( '/^last_name_/', $key ) ) {
-									$last_name = $value;
-								}
-
-								if ( preg_match( '/^email/', $key ) ) {
-									$email = $value;
-								}
-
-								if ( '' === $name ) {
-									if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-										$name = $first_name . ' ' . $last_name;
-									} elseif ( ! empty( $first_name ) ) {
-										$name = $first_name;
-									} else {
-										$name = $last_name;
-									}
-								} else {
-									$name = $name;
-								}
-
-								$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', esc_html__( 'Form Entry Approved', 'everest-forms' ) );
-								/* translators:%s: User name of form entry */
-								$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-								/* translators:%s: Form Entry Date */
-								$message .= '<br/>' . sprintf( __( 'We’re pleased to inform you that your form entry submitted on %s has been successfully approved.', 'everest-forms' ), $entry_date ) . '<br/>';
-								$message .= '<br/>' . __( 'Thank you for giving us your precious time', 'everest-forms' ) . '<br/>';
-								/* translators:%s: Site Name */
-								$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-								$message  = apply_filters( 'everest_forms_entry_approval_message', $message, $name, $entry_date, $site_name );
-							}
-							$email_obj = new EVF_Emails();
-							$email_obj->send( $email, $subject, $message );
+						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							++$count;
 						}
 					}
 					break;
 				case 'denied':
 					foreach ( $entry_ids as $entry_id ) {
-						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction, true ) ) {
-							$admin_email = esc_attr( get_bloginfo( 'admin_email' ) );
-							$header      = "Reply-To: {$admin_email} \r\n";
-							$header     .= 'Content-Type: text/html; charset=UTF-8';
-							$subject     = '';
-							$message     = '';
-
-							$entry      = evf_get_entry( $entry_id );
-							$entry_date = $entry->date_created;
-							$entry_data = $entry->meta;
-							$site_name  = get_option( 'blogname' );
-
-							$first_name = '';
-							$last_name  = '';
-							$email      = '';
-							$name       = '';
-
-							foreach ( $entry_data as $key => $value ) {
-								if ( preg_match( '/^name/', $key ) ) {
-									$name = $value;
-								}
-
-								if ( preg_match( '/^first_name_/', $key ) ) {
-									$first_name = $value;
-								}
-
-								if ( preg_match( '/^last_name_/', $key ) ) {
-									$last_name = $value;
-								}
-
-								if ( preg_match( '/^email/', $key ) ) {
-									$email = $value;
-								}
-
-								if ( '' === $name ) {
-									if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-										$name = $first_name . ' ' . $last_name;
-									} elseif ( ! empty( $first_name ) ) {
-										$name = $first_name;
-									} else {
-										$name = $last_name;
-									}
-								} else {
-									$name = $name;
-								}
-
-								$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', esc_html__( 'Form Entry Denied', 'everest-forms' ) );
-								/* translators:%s: User name of form entry */
-								$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-								/* translators:%s: Form Entry Date */
-								$message .= '<br/>' . sprintf( __( 'We regret to inform you that your form entry submitted on %s has been denied.', 'everest-forms' ), $entry_date ) . '<br/>';
-								$message .= '<br/>' . __( 'Thank you for giving us your precious time', 'everest-forms' ) . '<br/>';
-								/* translators:%s: Site Name */
-								$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-								$message  = apply_filters( 'everest_forms_entry_denial_message', $message, $name, $entry_date, $site_name );
-							}
-							$email_obj = new EVF_Emails();
-							$email_obj->send( $email, $subject, $message );
+						if ( EVF_Admin_Entries::update_status( $entry_id, $doaction ) ) {
 							++$count;
 						}
 					}

--- a/includes/admin/class-evf-admin-entries.php
+++ b/includes/admin/class-evf-admin-entries.php
@@ -514,7 +514,7 @@ class EVF_Admin_Entries {
 			$name       = '';
 
 			foreach ( $entry_meta as $key => $value ) {
-				if ( preg_match( '/^name/', $key ) ) {
+				if ( preg_match( '/^name_/', $key ) ) {
 					$name = $value;
 				}
 
@@ -571,7 +571,7 @@ class EVF_Admin_Entries {
 			$name       = '';
 
 			foreach ( $entry_meta as $key => $value ) {
-				if ( preg_match( '/^name/', $key ) ) {
+				if ( preg_match( '/^name_/', $key ) ) {
 					$name = $value;
 				}
 

--- a/includes/admin/class-evf-admin-entries.php
+++ b/includes/admin/class-evf-admin-entries.php
@@ -460,14 +460,17 @@ class EVF_Admin_Entries {
 	/**
 	 * Set entry status.
 	 *
-	 * @param int    $entry_id Entry ID.
-	 * @param string $status   Entry status.
+	 * @param int    $entry_id       Entry ID.
+	 * @param string $status         Entry status.
+	 * @param bool   $is_bulk_action Whether this status change came from a bulk action. Determined by the
+	 *                               caller (which knows its own context) rather than sniffed from request
+	 *                               data, since an unauthenticated/un-nonce-verified query var is not a
+	 *                               reliable signal.
 	 */
-	public static function update_status( $entry_id, $status = 'publish' ) {
+	public static function update_status( $entry_id, $status = 'publish', $is_bulk_action = false ) {
 		global $wpdb;
 
-		$update         = false;
-		$is_bulk_action = isset( $_GET['bulk_action'] ) && 'Apply' == $_GET['bulk_action'] ? true : false; // phpcs:ignore WordPress.Security.NonceVerification
+		$update = false;
 		if ( in_array( $status, array( 'star', 'unstar' ), true ) ) {
 			$update = $wpdb->update(
 				$wpdb->prefix . 'evf_entries',
@@ -511,6 +514,10 @@ class EVF_Admin_Entries {
 			$name       = '';
 
 			foreach ( $entry_meta as $key => $value ) {
+				if ( preg_match( '/^name/', $key ) ) {
+					$name = $value;
+				}
+
 				if ( preg_match( '/^first_name_/', $key ) ) {
 					$first_name = $value;
 				}
@@ -522,20 +529,20 @@ class EVF_Admin_Entries {
 				if ( preg_match( '/^email/', $key ) ) {
 					$email = $value;
 				}
-
-				if ( '' === $name ) {
-					if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-						$name = $first_name . ' ' . $last_name;
-					} elseif ( ! empty( $first_name ) ) {
-						$name = $first_name;
-					} else {
-						$name = $last_name;
-					}
-				}
-
-				$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', self::get_entry_status_email_subject( 'approval' ) );
-				$message = apply_filters( 'everest_forms_entry_approval_message', self::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 			}
+
+			if ( '' === $name ) {
+				if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
+					$name = $first_name . ' ' . $last_name;
+				} elseif ( ! empty( $first_name ) ) {
+					$name = $first_name;
+				} else {
+					$name = $last_name;
+				}
+			}
+
+			$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', self::get_entry_status_email_subject( 'approval' ) );
+			$message = apply_filters( 'everest_forms_entry_approval_message', self::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 
 			if ( ! $is_bulk_action && self::is_entry_status_email_enabled( 'approval' ) ) {
 				$email_obj = new EVF_Emails();
@@ -559,34 +566,40 @@ class EVF_Admin_Entries {
 			$last_name  = '';
 			$email      = '';
 			$site_name  = get_option( 'blogname', '' );
+			$subject    = '';
+			$message    = '';
 			$name       = '';
 
 			foreach ( $entry_meta as $key => $value ) {
-				if ( preg_match( '/^first_name/', $key ) ) {
+				if ( preg_match( '/^name/', $key ) ) {
+					$name = $value;
+				}
+
+				if ( preg_match( '/^first_name_/', $key ) ) {
 					$first_name = $value;
 				}
 
-				if ( preg_match( '/^last_name/', $key ) ) {
+				if ( preg_match( '/^last_name_/', $key ) ) {
 					$last_name = $value;
 				}
 
 				if ( preg_match( '/^email/', $key ) ) {
 					$email = $value;
 				}
-
-				if ( '' === $name ) {
-					if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-						$name = $first_name . ' ' . $last_name;
-					} elseif ( ! empty( $first_name ) ) {
-						$name = $first_name;
-					} else {
-						$name = $last_name;
-					}
-				}
-
-				$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', self::get_entry_status_email_subject( 'denial' ) );
-				$message = apply_filters( 'everest_forms_entry_denial_message', self::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 			}
+
+			if ( '' === $name ) {
+				if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
+					$name = $first_name . ' ' . $last_name;
+				} elseif ( ! empty( $first_name ) ) {
+					$name = $first_name;
+				} else {
+					$name = $last_name;
+				}
+			}
+
+			$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', self::get_entry_status_email_subject( 'denial' ) );
+			$message = apply_filters( 'everest_forms_entry_denial_message', self::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 
 			if ( ! $is_bulk_action && self::is_entry_status_email_enabled( 'denial' ) ) {
 				$email_obj = new EVF_Emails();

--- a/includes/admin/class-evf-admin-entries.php
+++ b/includes/admin/class-evf-admin-entries.php
@@ -399,6 +399,65 @@ class EVF_Admin_Entries {
 	}
 
 	/**
+	 * Get the default subject for an entry status email.
+	 *
+	 * @param string $type 'approval' or 'denial'.
+	 * @return string
+	 */
+	private static function get_entry_status_email_default_subject( $type ) {
+		return 'denial' === $type
+			? esc_html__( 'Entry Submission Denied', 'everest-forms' )
+			: esc_html__( 'Form Entry Approved', 'everest-forms' );
+	}
+
+	/**
+	 * Get the default message for an entry status email.
+	 *
+	 * @param string $type 'approval' or 'denial'.
+	 * @return string
+	 */
+	private static function get_entry_status_email_default_message( $type ) {
+		return 'denial' === $type
+			? __( 'Hey, {name}<br/><br/>We regret to inform you that your form entry submitted on {entry_date} has been denied.<br/><br/>Thank you for giving us your precious time.<br/><br/>From {site_name}', 'everest-forms' )
+			: __( 'Hey, {name}<br/><br/>We\'re pleased to inform you that your form entry submitted on {entry_date} has been successfully approved.<br/><br/>Thank you for giving us your precious time.<br/><br/>From {site_name}', 'everest-forms' );
+	}
+
+	/**
+	 * Get the (possibly customized) subject for an entry status email.
+	 *
+	 * @param string $type 'approval' or 'denial'.
+	 * @return string
+	 */
+	public static function get_entry_status_email_subject( $type ) {
+		return get_option( "everest_forms_entry_{$type}_email_subject", self::get_entry_status_email_default_subject( $type ) );
+	}
+
+	/**
+	 * Get the (possibly customized) message for an entry status email, with {tag} placeholders replaced.
+	 *
+	 * @param string $type       'approval' or 'denial'.
+	 * @param string $name       Entry submitter's name.
+	 * @param string $entry_date Entry submission date.
+	 * @param string $site_name  Site name.
+	 * @return string
+	 */
+	public static function get_entry_status_email_message( $type, $name, $entry_date, $site_name ) {
+		$message = get_option( "everest_forms_entry_{$type}_email_body", self::get_entry_status_email_default_message( $type ) );
+
+		return str_replace( array( '{name}', '{entry_date}', '{site_name}' ), array( $name, $entry_date, $site_name ), $message );
+	}
+
+	/**
+	 * Whether an entry status email type is enabled.
+	 *
+	 * @param string $type 'approval' or 'denial'.
+	 * @return bool
+	 */
+	public static function is_entry_status_email_enabled( $type ) {
+		return 'no' !== get_option( "everest_forms_entry_{$type}_email_enable", 'yes' );
+	}
+
+	/**
 	 * Set entry status.
 	 *
 	 * @param int    $entry_id Entry ID.
@@ -474,18 +533,11 @@ class EVF_Admin_Entries {
 					}
 				}
 
-				$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', esc_html__( 'Form Entry Approved', 'everest-forms' ) );
-				/* translators:%s: User name of form entry */
-				$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-				/* translators:%s: Form Entry Date */
-				$message .= '<br/>' . sprintf( __( 'We\'re pleased to inform you that your form entry submitted on %s has been successfully approved.', 'everest-forms' ), $entry_date ) . '<br/>';
-				$message .= '<br/>' . __( 'Thank you for giving us your precious time.', 'everest-forms' ) . '<br/>';
-				/* translators:%s: Site Name*/
-				$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-				$message  = apply_filters( 'everest_forms_entry_approval_message', $message, $name, $entry_date, $site_name );
+				$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', self::get_entry_status_email_subject( 'approval' ) );
+				$message = apply_filters( 'everest_forms_entry_approval_message', self::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 			}
 
-			if ( ! $is_bulk_action ) {
+			if ( ! $is_bulk_action && self::is_entry_status_email_enabled( 'approval' ) ) {
 				$email_obj = new EVF_Emails();
 				$email_obj->send( $email, $subject, $message );
 			}
@@ -532,18 +584,11 @@ class EVF_Admin_Entries {
 					}
 				}
 
-				$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', esc_html__( 'Entry Submission Denied', 'everest-forms' ) );
-				/* translators:%s: User name of form entry */
-				$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-				/* translators:%s: Form Entry Date */
-				$message .= '<br/>' . sprintf( __( 'We regret to inform you that your form entry submitted on %s has been denied.', 'everest-forms' ), $entry_date ) . '<br/>';
-				$message .= '<br/>' . __( 'Thank you for giving us your precious time.', 'everest-forms' ) . '<br/>';
-				/* translator: %s: Site Name */
-				$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-				$message  = apply_filters( 'everest_forms_entry_denial_message', $message, $name, $entry_date, $site_name );
+				$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', self::get_entry_status_email_subject( 'denial' ) );
+				$message = apply_filters( 'everest_forms_entry_denial_message', self::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 			}
 
-			if ( ! $is_bulk_action ) {
+			if ( ! $is_bulk_action && self::is_entry_status_email_enabled( 'denial' ) ) {
 				$email_obj = new EVF_Emails();
 				$email_obj->send( $email, $subject, $message );
 			}

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -1918,20 +1918,14 @@ class EVF_Form_Task {
 							}
 						}
 
-						$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', esc_html__( 'Form Entry Approved', 'everest-forms' ) );
-						// translators: %s is the name of the user
-						$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-						// translators: %s is the entry_date.
-						$message .= '<br/>' . sprintf( __( 'We’re pleased to inform you that your form entry submitted on %s has been successfully approved.', 'everest-forms' ), $entry_date ) . '<br/>';
-						$message .= '<br/>' . __( 'Thank you for giving us your precious time.', 'everest-forms' ) . '<br/>';
-						// translators: %s is the site_name.
-						$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-						// translators: %s is the message.
-						$message = apply_filters( 'everest_forms_entry_approval_message', $message, $name, $entry_date, $site_name );
+						$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'approval' ) );
+						$message = apply_filters( 'everest_forms_entry_approval_message', EVF_Admin_Entries::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 					}
 
-					$email_obj = new EVF_Emails();
-					$test      = $email_obj->send( $email, $subject, $message );
+					if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'approval' ) ) {
+						$email_obj = new EVF_Emails();
+						$email_obj->send( $email, $subject, $message );
+					}
 					wp_redirect( $evf_entry_redirect_url );
 				}
 			}
@@ -1999,20 +1993,15 @@ class EVF_Form_Task {
 							}
 						}
 
-						$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', esc_html__( 'Entry Submission Denied', 'everest-forms' ) );
-						// translators: %s is the name of the user
-						$message = sprintf( __( 'Hey, %s', 'everest-forms' ), $name ) . '<br/>';
-						// translators: %s is the entry_date.
-						$message .= '<br/>' . sprintf( __( 'We’re sorry to inform you that your form entry submitted on %s has been denied.', 'everest-forms' ), $entry_date ) . '<br/>';
-						$message .= '<br/>' . __( 'Thank you for giving us your precious time.', 'everest-forms' ) . '<br/>';
-						// translators: %s is the site_name.
-						$message .= '<br/>' . sprintf( __( 'From %s', 'everest-forms' ), $site_name );
-						// translators: %s is the message.
-						$message = apply_filters( 'everest_forms_entry_denial_message', $message, $name, $entry_date, $site_name );
+						$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'denial' ) );
+						$message = apply_filters( 'everest_forms_entry_denial_message', EVF_Admin_Entries::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
 
 					}
-					$email_obj = new EVF_Emails();
-					$email_obj->send( $email, $subject, $message );
+
+					if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'denial' ) ) {
+						$email_obj = new EVF_Emails();
+						$email_obj->send( $email, $subject, $message );
+					}
 					wp_redirect( $evf_entry_redirect_url );
 				}
 			}

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -87,6 +87,7 @@ class EVF_Form_Task {
 		 */
 		add_action( 'before_delete_post', array( $this, 'delete_entry_files_before_form_delete' ), 10, 1 );
 		add_action( 'everest_forms_before_delete_entries', array( $this, 'delete_entry_files' ), 10, 1 );
+		add_action( 'everest_forms_after_delete_entries', array( $this, 'evf_cleanup_approval_tokens' ), 10, 2 );
 	}
 
 	/**
@@ -1868,68 +1869,85 @@ class EVF_Form_Task {
 			return;
 		}
 
-		if ( current_user_can( 'edit_users' ) ) {
-			global $wpdb;
-			$evf_admin_approve_entry_token_raw = sanitize_text_field( wp_unslash( $_GET['evf_admin_approval_entry_token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! current_user_can( 'edit_users' ) ) {
+			wp_die( esc_html__( 'You are not allowed to perform this action.', 'everest-forms' ), '', array( 'response' => 403 ) );
+		}
 
-			$evf_admin_approval_entry_enable = get_option( 'everest_forms_admin_approval_entries_enable', 'no' );
-			$evf_admin_form_id               = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
-			$evf_admin_entry_id              = isset( $_GET['entry_id'] ) ? absint( $_GET['entry_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
-			$evf_entry_redirect_url          = admin_url() . 'admin.php?page=evf-entries&form_id=' . $evf_admin_form_id . '&view-entry=' . $evf_admin_entry_id;
-			$evf_admin_entry_saved_token     = get_option( 'everest_forms_admin_entry_approval_token', array() );
-			$site_name                       = get_option( 'blogname' );
+		global $wpdb;
+		$evf_admin_approve_entry_token_raw = sanitize_text_field( wp_unslash( $_GET['evf_admin_approval_entry_token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
-			if ( 'yes' === $evf_admin_approval_entry_enable ) {
-				$evf_admin_approval_entry_token = isset( $_GET['evf_admin_approval_entry_token'] ) ? sanitize_text_field( wp_unslash( $_GET['evf_admin_approval_entry_token'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-				if ( in_array( $evf_admin_approve_entry_token_raw, $evf_admin_entry_saved_token ) ) {
-					$evf_admin_approval_approved = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}evf_entries SET status = %s WHERE entry_id = %s ", 'publish', $evf_admin_entry_id ) );
-					$entry                       = evf_get_entry( $evf_admin_entry_id );
-					$entry_meta                  = $entry->meta;
-					$first_name                  = '';
-					$last_name                   = '';
-					$email                       = '';
-					$entry_date                  = $entry->date_created;
-					$name                        = '';
+		$evf_admin_approval_entry_enable = get_option( 'everest_forms_admin_approval_entries_enable', 'no' );
+		$evf_admin_form_id               = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+		$evf_admin_entry_id              = isset( $_GET['entry_id'] ) ? absint( $_GET['entry_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+		$evf_entry_redirect_url          = admin_url() . 'admin.php?page=evf-entries&form_id=' . $evf_admin_form_id . '&view-entry=' . $evf_admin_entry_id;
+		$evf_admin_entry_saved_token     = get_option( 'everest_forms_admin_entry_approval_token', array() );
+		$site_name                       = get_option( 'blogname' );
 
-					foreach ( $entry_meta as $key => $value ) {
-						if ( preg_match( '/^name/', $key ) ) {
-							$name = $value;
-						}
+		if ( 'yes' !== $evf_admin_approval_entry_enable ) {
+			wp_die( esc_html__( 'Entry approval is not enabled for this site.', 'everest-forms' ), '', array( 'response' => 403 ) );
+		}
 
-						if ( preg_match( '/^first_name_/', $key ) ) {
-							$first_name = $value;
-						}
+		$evf_approval_key         = 'approval_token_' . $evf_admin_entry_id;
+		$evf_admin_expected_token = isset( $evf_admin_entry_saved_token[ $evf_approval_key ] ) ? $evf_admin_entry_saved_token[ $evf_approval_key ] : '';
 
-						if ( preg_match( '/^last_name_/', $key ) ) {
-							$last_name = $value;
-						}
+		// Bind the token to the specific entry it was issued for instead of accepting any valid token in the option.
+		if ( '' === $evf_admin_expected_token || ! hash_equals( $evf_admin_expected_token, $evf_admin_approve_entry_token_raw ) ) {
+			wp_die( esc_html__( 'This approval link is invalid or has already been used.', 'everest-forms' ), '', array( 'response' => 403, 'back_link' => true ) );
+		}
 
-						if ( preg_match( '/^email/', $key ) ) {
-							$email = $value;
-						}
+		$evf_admin_approval_approved = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}evf_entries SET status = %s WHERE entry_id = %d ", 'publish', $evf_admin_entry_id ) );
+		$entry                       = evf_get_entry( $evf_admin_entry_id );
+		$entry_meta                  = $entry->meta;
+		$first_name                  = '';
+		$last_name                   = '';
+		$email                       = '';
+		$entry_date                  = $entry->date_created;
+		$name                        = '';
+		$subject                     = '';
+		$message                     = '';
 
-						if ( '' === $name ) {
-							if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-								$name = $first_name . ' ' . $last_name;
-							} elseif ( ! empty( $first_name ) ) {
-								$name = $first_name;
-							} else {
-								$name = $last_name;
-							}
-						}
+		foreach ( $entry_meta as $key => $value ) {
+			if ( preg_match( '/^name/', $key ) ) {
+				$name = $value;
+			}
 
-						$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'approval' ) );
-						$message = apply_filters( 'everest_forms_entry_approval_message', EVF_Admin_Entries::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
-					}
+			if ( preg_match( '/^first_name_/', $key ) ) {
+				$first_name = $value;
+			}
 
-					if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'approval' ) ) {
-						$email_obj = new EVF_Emails();
-						$email_obj->send( $email, $subject, $message );
-					}
-					wp_redirect( $evf_entry_redirect_url );
-				}
+			if ( preg_match( '/^last_name_/', $key ) ) {
+				$last_name = $value;
+			}
+
+			if ( preg_match( '/^email/', $key ) ) {
+				$email = $value;
 			}
 		}
+
+		if ( '' === $name ) {
+			if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
+				$name = $first_name . ' ' . $last_name;
+			} elseif ( ! empty( $first_name ) ) {
+				$name = $first_name;
+			} else {
+				$name = $last_name;
+			}
+		}
+
+		$subject = apply_filters( 'everest_forms_entry_submission_approval_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'approval' ) );
+		$message = apply_filters( 'everest_forms_entry_approval_message', EVF_Admin_Entries::get_entry_status_email_message( 'approval', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
+
+		if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'approval' ) ) {
+			$email_obj = new EVF_Emails();
+			$email_obj->send( $email, $subject, $message );
+		}
+
+		// Invalidate both the approve and deny links for this entry now that it has been actioned.
+		unset( $evf_admin_entry_saved_token[ $evf_approval_key ], $evf_admin_entry_saved_token[ 'denial_token_' . $evf_admin_entry_id ] );
+		update_option( 'everest_forms_admin_entry_approval_token', $evf_admin_entry_saved_token );
+
+		wp_redirect( $evf_entry_redirect_url );
+		exit;
 	}
 
 	/**
@@ -1942,70 +1960,85 @@ class EVF_Form_Task {
 			return;
 		}
 
-		if ( current_user_can( 'edit_users' ) ) {
-			global $wpdb;
+		if ( ! current_user_can( 'edit_users' ) ) {
+			wp_die( esc_html__( 'You are not allowed to perform this action.', 'everest-forms' ), '', array( 'response' => 403 ) );
+		}
 
-			$evf_admin_approve_entry_token_raw = isset( $_GET['evf_admin_denial_entry_token'] ) ? sanitize_text_field( wp_unslash( $_GET['evf_admin_denial_entry_token'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-			$evf_admin_approval_entry_enable   = get_option( 'everest_forms_admin_approval_entries_enable', 'no' );
-			$evf_admin_form_id                 = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
-			$evf_admin_entry_id                = isset( $_GET['entry_id'] ) ? absint( $_GET['entry_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
-			$evf_entry_redirect_url            = admin_url() . 'admin.php?page=evf-entries&form_id=' . $evf_admin_form_id . '&view-entry=' . $evf_admin_entry_id;
-			$evf_admin_entry_saved_token       = get_option( 'everest_forms_admin_entry_approval_token', array() );
-			$site_name                         = get_option( 'blogname' );
+		global $wpdb;
 
-			if ( 'yes' === $evf_admin_approval_entry_enable ) {
+		$evf_admin_denial_entry_token_raw = sanitize_text_field( wp_unslash( $_GET['evf_admin_denial_entry_token'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		$evf_admin_approval_entry_enable  = get_option( 'everest_forms_admin_approval_entries_enable', 'no' );
+		$evf_admin_form_id                = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+		$evf_admin_entry_id               = isset( $_GET['entry_id'] ) ? absint( $_GET['entry_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+		$evf_entry_redirect_url           = admin_url() . 'admin.php?page=evf-entries&form_id=' . $evf_admin_form_id . '&view-entry=' . $evf_admin_entry_id;
+		$evf_admin_entry_saved_token      = get_option( 'everest_forms_admin_entry_approval_token', array() );
+		$site_name                        = get_option( 'blogname' );
 
-				$evf_admin_denial_entry_token = isset( $_GET['evf_admin_denial_entry_token'] ) ? sanitize_text_field( wp_unslash( $_GET['evf_admin_denial_entry_token'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-				if ( in_array( $evf_admin_approve_entry_token_raw, $evf_admin_entry_saved_token ) ) {
-					$evf_admin_approval_denied = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}evf_entries SET status = %s WHERE entry_id = %s ", 'denied', $evf_admin_entry_id ) );
-					$entry                     = evf_get_entry( $evf_admin_entry_id );
-					$entry_meta                = $entry->meta;
-					$entry_date                = $entry->date_created;
-					$first_name                = '';
-					$last_name                 = '';
-					$email                     = '';
-					$name                      = '';
+		if ( 'yes' !== $evf_admin_approval_entry_enable ) {
+			wp_die( esc_html__( 'Entry approval is not enabled for this site.', 'everest-forms' ), '', array( 'response' => 403 ) );
+		}
 
-					foreach ( $entry_meta as $key => $value ) {
-						if ( preg_match( '/^name/', $key ) ) {
-							$name = $value;
-						}
+		$evf_denial_key           = 'denial_token_' . $evf_admin_entry_id;
+		$evf_admin_expected_token = isset( $evf_admin_entry_saved_token[ $evf_denial_key ] ) ? $evf_admin_entry_saved_token[ $evf_denial_key ] : '';
 
-						if ( preg_match( '/^first_name_/', $key ) ) {
-							$first_name = $value;
-						}
+		// Bind the token to the specific entry it was issued for instead of accepting any valid token in the option.
+		if ( '' === $evf_admin_expected_token || ! hash_equals( $evf_admin_expected_token, $evf_admin_denial_entry_token_raw ) ) {
+			wp_die( esc_html__( 'This denial link is invalid or has already been used.', 'everest-forms' ), '', array( 'response' => 403, 'back_link' => true ) );
+		}
 
-						if ( preg_match( '/^last_name_/', $key ) ) {
-							$last_name = $value;
-						}
+		$evf_admin_approval_denied = $wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->prefix}evf_entries SET status = %s WHERE entry_id = %d ", 'denied', $evf_admin_entry_id ) );
+		$entry                     = evf_get_entry( $evf_admin_entry_id );
+		$entry_meta                = $entry->meta;
+		$entry_date                = $entry->date_created;
+		$first_name                = '';
+		$last_name                 = '';
+		$email                     = '';
+		$name                      = '';
+		$subject                  = '';
+		$message                  = '';
 
-						if ( preg_match( '/^email/', $key ) ) {
-							$email = $value;
-						}
+		foreach ( $entry_meta as $key => $value ) {
+			if ( preg_match( '/^name/', $key ) ) {
+				$name = $value;
+			}
 
-						if ( '' === $name ) {
-							if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-								$name = $first_name . ' ' . $last_name;
-							} elseif ( ! empty( $first_name ) ) {
-								$name = $first_name;
-							} else {
-								$name = $last_name;
-							}
-						}
+			if ( preg_match( '/^first_name_/', $key ) ) {
+				$first_name = $value;
+			}
 
-						$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'denial' ) );
-						$message = apply_filters( 'everest_forms_entry_denial_message', EVF_Admin_Entries::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
+			if ( preg_match( '/^last_name_/', $key ) ) {
+				$last_name = $value;
+			}
 
-					}
-
-					if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'denial' ) ) {
-						$email_obj = new EVF_Emails();
-						$email_obj->send( $email, $subject, $message );
-					}
-					wp_redirect( $evf_entry_redirect_url );
-				}
+			if ( preg_match( '/^email/', $key ) ) {
+				$email = $value;
 			}
 		}
+
+		if ( '' === $name ) {
+			if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
+				$name = $first_name . ' ' . $last_name;
+			} elseif ( ! empty( $first_name ) ) {
+				$name = $first_name;
+			} else {
+				$name = $last_name;
+			}
+		}
+
+		$subject = apply_filters( 'everest_forms_entry_submission_denial_subject', EVF_Admin_Entries::get_entry_status_email_subject( 'denial' ) );
+		$message = apply_filters( 'everest_forms_entry_denial_message', EVF_Admin_Entries::get_entry_status_email_message( 'denial', $name, $entry_date, $site_name ), $name, $entry_date, $site_name );
+
+		if ( EVF_Admin_Entries::is_entry_status_email_enabled( 'denial' ) ) {
+			$email_obj = new EVF_Emails();
+			$email_obj->send( $email, $subject, $message );
+		}
+
+		// Invalidate both the approve and deny links for this entry now that it has been actioned.
+		unset( $evf_admin_entry_saved_token[ $evf_denial_key ], $evf_admin_entry_saved_token[ 'approval_token_' . $evf_admin_entry_id ] );
+		update_option( 'everest_forms_admin_entry_approval_token', $evf_admin_entry_saved_token );
+
+		wp_redirect( $evf_entry_redirect_url );
+		exit;
 	}
 
 	/**
@@ -2017,23 +2050,46 @@ class EVF_Form_Task {
 	 * @since 2.0.9
 	 */
 	public function evf_set_approval_status( $entry_id, $form_data ) {
-		$evf_admin_approval_token_list  = array();
 		$form_id                        = isset( $form_data['id'] ) ? $form_id['id'] : '';
 		$evf_admin_entry_enable         = get_option( 'everest_forms_admin_approval_entries_enable', 'no' );
 		$evf_admin_entry_approval_token = get_option( 'everest_forms_admin_entry_approval_token', array() );
 		$evf_approval_key               = 'approval_token_' . $entry_id;
+		$evf_denial_key                 = 'denial_token_' . $entry_id;
 
 		// Checks if admin approval entry is enabled.
 		if ( ! isset( $evf_admin_entry_enable ) ) {
 			return;
 		} else {
-			$token              = evf_get_random_string( 20 );
-			$evf_approval_token = array(
-				$evf_approval_key => $token,
+			// Separate tokens for approve and deny so one link can't be used to perform the other action.
+			$evf_new_token = array_merge(
+				$evf_admin_entry_approval_token,
+				array(
+					$evf_approval_key => evf_get_random_string( 20 ),
+					$evf_denial_key   => evf_get_random_string( 20 ),
+				)
 			);
-			$evf_new_token      = array_merge( $evf_admin_entry_approval_token, $evf_approval_token );
 			update_option( 'everest_forms_admin_entry_approval_token', $evf_new_token );
 		}
+	}
+
+	/**
+	 * Removes the approve/deny tokens for an entry once it no longer exists, so the
+	 * option doesn't accumulate orphaned tokens for deleted entries.
+	 *
+	 * @param int $form_id  Form ID.
+	 * @param int $entry_id Entry ID.
+	 *
+	 * @since 3.6.0
+	 */
+	public function evf_cleanup_approval_tokens( $form_id, $entry_id ) {
+		$evf_admin_entry_approval_token = get_option( 'everest_forms_admin_entry_approval_token', array() );
+
+		if ( empty( $evf_admin_entry_approval_token ) ) {
+			return;
+		}
+
+		unset( $evf_admin_entry_approval_token[ 'approval_token_' . $entry_id ], $evf_admin_entry_approval_token[ 'denial_token_' . $entry_id ] );
+		update_option( 'everest_forms_admin_entry_approval_token', $evf_admin_entry_approval_token );
 	}
 
 	/**

--- a/includes/class-evf-form-task.php
+++ b/includes/class-evf-form-task.php
@@ -1907,7 +1907,7 @@ class EVF_Form_Task {
 		$message                     = '';
 
 		foreach ( $entry_meta as $key => $value ) {
-			if ( preg_match( '/^name/', $key ) ) {
+			if ( preg_match( '/^name_/', $key ) ) {
 				$name = $value;
 			}
 
@@ -1981,6 +1981,14 @@ class EVF_Form_Task {
 		$evf_denial_key           = 'denial_token_' . $evf_admin_entry_id;
 		$evf_admin_expected_token = isset( $evf_admin_entry_saved_token[ $evf_denial_key ] ) ? $evf_admin_entry_saved_token[ $evf_denial_key ] : '';
 
+		// Fall back to the pre-existing shared approval token for deny links sent before entries got a separate denial token.
+		if ( '' === $evf_admin_expected_token ) {
+			$legacy_key               = 'approval_token_' . $evf_admin_entry_id;
+			$evf_admin_expected_token = isset( $evf_admin_entry_saved_token[ $legacy_key ] )
+				? $evf_admin_entry_saved_token[ $legacy_key ]
+				: '';
+		}
+
 		// Bind the token to the specific entry it was issued for instead of accepting any valid token in the option.
 		if ( '' === $evf_admin_expected_token || ! hash_equals( $evf_admin_expected_token, $evf_admin_denial_entry_token_raw ) ) {
 			wp_die( esc_html__( 'This denial link is invalid or has already been used.', 'everest-forms' ), '', array( 'response' => 403, 'back_link' => true ) );
@@ -1998,7 +2006,7 @@ class EVF_Form_Task {
 		$message                  = '';
 
 		foreach ( $entry_meta as $key => $value ) {
-			if ( preg_match( '/^name/', $key ) ) {
+			if ( preg_match( '/^name_/', $key ) ) {
 				$name = $value;
 			}
 
@@ -2057,19 +2065,19 @@ class EVF_Form_Task {
 		$evf_denial_key                 = 'denial_token_' . $entry_id;
 
 		// Checks if admin approval entry is enabled.
-		if ( ! isset( $evf_admin_entry_enable ) ) {
+		if ( 'yes' !== $evf_admin_entry_enable ) {
 			return;
-		} else {
-			// Separate tokens for approve and deny so one link can't be used to perform the other action.
-			$evf_new_token = array_merge(
-				$evf_admin_entry_approval_token,
-				array(
-					$evf_approval_key => evf_get_random_string( 20 ),
-					$evf_denial_key   => evf_get_random_string( 20 ),
-				)
-			);
-			update_option( 'everest_forms_admin_entry_approval_token', $evf_new_token );
 		}
+
+		// Separate tokens for approve and deny so one link can't be used to perform the other action.
+		$evf_new_token = array_merge(
+			$evf_admin_entry_approval_token,
+			array(
+				$evf_approval_key => evf_get_random_string( 20 ),
+				$evf_denial_key   => evf_get_random_string( 20 ),
+			)
+		);
+		update_option( 'everest_forms_admin_entry_approval_token', $evf_new_token );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- The emails sent to a user when their entry is approved or denied were fully hardcoded (only customizable via PHP filters, no settings UI).
- Added shared helpers on `EVF_Admin_Entries` (`get_entry_status_email_subject()`, `get_entry_status_email_message()`, `is_entry_status_email_enabled()`) that read from options, falling back to the original hardcoded copy as defaults.
- Wired both the admin-UI approve/deny action (`EVF_Admin_Entries::update_status()`) and the token-link approve/deny flow (`EVF_Form_Task::evf_admin_approve_entry()`/`evf_admin_deny_entry()`) through these helpers, so both paths stay in sync.
- All pre-existing filters (`everest_forms_entry_submission_approval_subject`, `everest_forms_entry_approval_message`, `everest_forms_entry_submission_denial_subject`, `everest_forms_entry_denial_message`) still fire with the same signature.
- Fixed a pre-existing bug: the token-link deny handler filtered its subject through the *approval* filter name instead of the denial one.
- Settings UI (Subject/Message/Enable toggle for both emails) is added in a companion PR on `everest-forms-pro` under Settings > Advanced > Entries Management, next to the existing admin-approval-entries settings.

Scope note: this ticket's "entry approval notification to admin" item turned out to be dead code on inspection — Pro already has Subject/Message/To-Address settings for it, but no code path anywhere actually sends that email (the approval token is generated but never emailed). Left untouched here; flagging as a separate follow-up rather than building a new send path under this ticket.

## Test plan
- [ ] Approve/deny an entry from the Entries list admin UI, confirm the customized subject/message is used
- [ ] Click an approve/deny token link (from the admin's own entry-approval email, if the admin notification is separately configured) and confirm the same customized content is used
- [ ] Toggle the enable switch off for one email type and confirm it stops sending while the other still works
- [ ] Confirm a legacy `everest_forms_entry_approval_message` / `everest_forms_entry_denial_message` filter still fires and can alter the final message

Jira: EVF-2724
Companion PR (everest-forms-pro settings UI): link to follow