### PR TITLE
Fix: integration disconnect AJAX handler not registering provider hooks

### DIFF
--- a/includes/class-evf-ajax.php
+++ b/includes/class-evf-ajax.php
@@ -1040,6 +1040,10 @@ class EVF_AJAX {
 			);
 		}
 
+		if ( ! EVF()->integrations ) {
+			EVF()->integrations = new EVF_Integrations();
+		}
+
 		do_action( 'everest_forms_integration_account_disconnect_' . ( isset( $_POST['source'] ) ? sanitize_text_field( wp_unslash( $_POST['source'] ) ) : '' ), $_POST );
 
 		$connected_accounts = get_option( 'everest_forms_integrations', false );


### PR DESCRIPTION
## Summary
- `EVF_Ajax::integration_disconnect()` fires `do_action( 'everest_forms_integration_account_disconnect_' . $source, $_POST )`, but provider classes (GoogleDrive, Dropbox, GoogleCalendar, OneDrive, Amazon S3) only register that hook in their constructor, and `EVF_Integrations` (which instantiates every provider class) is normally built on WordPress's `current_screen` hook — which never fires during an `admin-ajax.php` request. So the hook has no listener, and disconnect silently falls through to generic key-based lookup logic meant for simple API-key integrations, returning `"Connection missing"`.
- `integration_connect()` already works around this exact problem (added in #1596, "Fix - Brevo connection issue"). This PR applies the identical fix to `integration_disconnect()`.

Fixes: https://themegrill.atlassian.net/browse/EVF-2727

## Test plan
- [ ] Authenticate Google Drive (or Dropbox / Google Calendar / OneDrive / Amazon S3) under Everest Forms > Settings > Integrations.
- [ ] Click "Remove Authentication" and confirm the account actually disconnects (reverts to the "Authenticate" state) instead of silently failing with "Connection missing".