### PR TITLE
Fix: User Registration email messages lose line breaks on save (EVF-2723)

### DIFF
--- a/includes/evf-core-functions.php
+++ b/includes/evf-core-functions.php
@@ -4781,7 +4781,7 @@ function evf_sanitize_builder($post_data = array())
 			$value = wp_kses_post( $data->value );
 		} elseif ( 'settings[external_url]' === $data->name ) {
 			$value = esc_url_raw( $data->value );
-		} elseif ( preg_match( '/evf_email_message/', $data->name ) || preg_match( '/telegram_message/', $data->name ) || preg_match( '/slack_message/', $data->name ) ) {
+		} elseif ( preg_match( '/evf_email_message/', $data->name ) || preg_match( '/telegram_message/', $data->name ) || preg_match( '/slack_message/', $data->name ) || preg_match( '/user_registration_email_.*_message/', $data->name ) ) {
 			$value = wp_kses_post( $data->value );
 		} elseif ( preg_match( '/calculation_field/', $data->name ) ) {
 			$value = wp_kses_post( $data->value );


### PR DESCRIPTION
## Problem

everest-forms-pro#1189 makes the User Registration addon's email Subject/Message customizable per form, saved through the classic builder like any other panel field. Multi-paragraph messages were silently losing their line breaks on every save — `Hi {username},\n\nWelcome!\n\nThanks!` came back as `Hi {username}, Welcome! Thanks!`.

## Root cause

`evf_sanitize_builder()` decides how to sanitize each posted field by matching its name against a fixed allowlist — `evf_email_message`, `telegram_message`, `slack_message`, `calculation_field`, `successful_form_submission_message` get `wp_kses_post()` (preserves line breaks); everything else falls through to `sanitize_text_field()`, which collapses them into single spaces. The new `user_registration_email_{type}_message` field names don't match any existing pattern.

## Fix

Adds `user_registration_email_.*_message` to the same allowlist branch — the same mechanism already used for every other addon's message field, not a new pattern.

## Testing

Verified in the builder: typed a message with a blank line between two paragraphs into a User Registration email template, saved, reloaded — the blank line now persists. Confirmed the actual email that gets sent (via `EVF_User_Activation`) also carries the intact message.

## Related

Companion to wpeverest/everest-forms-pro#1189 (per-form User Registration email templates) — that PR's fields are what exercise this bug. No user-facing change on its own; this only affects the new field names introduced there.